### PR TITLE
chore(deps): update development dependencies

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -20,12 +20,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - name: Install pinned dependencies

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create or update the release pull request
-        uses: googleapis/release-please-action@8b8fd2cc23b2e18957157a9d923d75aa0c6f6ad5 # v4
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Goal

Consolidate the reviewed Dependabot updates into one dependency pull request and bring the CI runtime to the current Node.js LTS.

Supersedes #11, #12, and #13.

## Changes

- Update `actions/checkout` from v4.4.0 to v7.0.1, pinned to the immutable release commit.
- Update `actions/setup-node` from v4.4.0 to v7.0.0, pinned to the immutable release commit.
- Update `googleapis/release-please-action` from v4.4.1 to v5.0.0, pinned to the immutable release commit.
- Run CI on Node.js 24 LTS instead of Node.js 22.
- Confirm `@abaplint/cli` 2.120.18 is already current; no npm lockfile change is needed.

## Compatibility review

- The checkout v7 behavior change affects `pull_request_target` and `workflow_run`; this repository's quality workflow uses `pull_request`, so it is unaffected.
- Setup Node v7 preserves the inputs used here.
- Release Please v5 preserves the configured inputs; its action runtime changes from Node 20 to Node 24.
- GitHub-hosted `ubuntu-latest` runners meet the Node 24 action runtime requirement.

## Validation

- `npm ci`
- `npm test` — abaplint 2.120.18, 0 findings across 4 files
- `npm audit` — 0 vulnerabilities
- Parsed all repository YAML and JSON files
- `git diff --check`
