### PR TITLE
fix: support WebGUI query editor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ These rules apply to every change in this repository. Read [docs/development.md]
 - Native abapGit is the source of truth for round-tripping complete SAP repository objects, including metadata XML, screens, text elements, authorization objects, tables, and transactions.
 - The ABAP 7.50 and S/4HANA 2023 systems are validation targets. Never treat an unexported system change as complete.
 - ARC-1 is the preferred interface for system context, focused object reads, syntax checks, ABAP Unit, and ATC. A source-only ARC-1 mirror is useful for inspection but is not a complete abapGit deployment.
+- NPL/SAP_BASIS 750 is an ARC-1/ADT-only target. Do not use FLP, WebGUI, SAP GUI, or browser automation there. UI/browser smoke belongs to A4H/SAP_BASIS 758.
 
 ## Compatibility contract
 
@@ -26,7 +27,7 @@ For changes that affect `src/` or live behavior:
 4. Write an implementation/test/rollback plan in `docs/plans/`, including ABAP 7.50 compatibility, Clean ABAP/Clean Core, abaplint, ABAP Unit, live activation/syntax/ATC, safe browser smoke, and ST22 delta. Review the plan before production changes.
 5. Implement the smallest change that turns the test green. Refactor only while the complete suite remains green. Edit source locally for source-only changes; create structural SAP objects in a development system and export them with native abapGit instead of inventing serializer XML.
 6. Run `npm ci`, `npm test`, `git diff --check`, a complete diff review, and the relevant security/authorization review. Deploy the exact candidate to each available SAP target without pretending that the shared abapGit `master` link represents an unmerged branch.
-7. On SAP_BASIS 750 first when available, then S/4HANA 2023, require controlled activation, active syntax, all ABAP Unit tests, complete ATC runs or explicit prerequisite failures, safe smoke, and ST22 delta. A failed/unavailable gate is never a pass.
+7. On SAP_BASIS 750 first when available, then S/4HANA 2023, require controlled activation, active syntax, all ABAP Unit tests, and complete ATC runs or explicit prerequisite failures. Run safe browser smoke and ST22 delta on A4H only. A failed/unavailable gate is never a pass.
 8. Perform a final implementation review, update finding evidence, commit with a Conventional Commit subject, push the branch, open a pull request, and wait for required CI to become green.
 9. After the first green PR run, audit the plan, implementation, test evidence, CI output, and development process. Apply useful process/documentation improvements to the same PR, move its plan to `docs/plans/finished/`, push, and wait for CI again.
 10. Merge only after the maintainer accepts any recorded live-system limitations. Pull the resulting `master`, verify Release Please behavior, and do not manually tag an ordinary release.
@@ -34,6 +35,8 @@ For changes that affect `src/` or live behavior:
 For a source-only candidate, a controlled direct source deployment is preferable to switching the shared native-abapGit repository away from `master`. Record the candidate commit/hash and activate only the intended object. Structural changes still require a real native-abapGit round trip and may need a dedicated package/system to avoid changing shared objects underneath other work.
 
 If ARC-1 authentication or a live system is unavailable, local checks may continue, but do not claim live validation. Record the missing gate in the PR and complete it before merge unless the maintainer explicitly accepts the risk.
+
+NPL currently lacks ZTOAD's transparent table. SAP_BASIS 750 has no ADT transparent-table create endpoint, so ARC-1 cannot provision it safely. Never substitute a DDIC structure. Until the real table is provisioned outside the ADT-only workflow, record NPL ZTOAD activation/syntax/Unit/ATC as blocked even though the ARC-1 object lifecycle itself is proven usable.
 
 ## Testing rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,17 +22,19 @@ These rules apply to every change in this repository. Read [docs/development.md]
 For changes that affect `src/` or live behavior:
 
 1. Start a short-lived `codex/<finding-id>` branch from current `master`. `master` remains the stable integration/release branch; never push a red or incomplete state to it. Keep the shared native-abapGit repository on `master` unless a structural-object test has an explicitly coordinated branch procedure.
-2. Start from a clean native-abapGit/system state, select one finding, research the issue and dependencies, reproduce it with sanitized inputs, and identify the root cause. Verify that every permanent test fixture exists on all claimed target releases.
+2. Start from a clean native-abapGit/system state, select one finding, research the issue and dependencies, reproduce it with sanitized inputs, and identify the root cause. Verify that every permanent test fixture and every serialized UI prerequisite needed by the smoke test exists on all claimed target releases.
 3. Add the smallest failing regression test and replay it against the original production code so the intended red failure is recorded.
 4. Write an implementation/test/rollback plan in `docs/plans/`, including ABAP 7.50 compatibility, Clean ABAP/Clean Core, abaplint, ABAP Unit, live activation/syntax/ATC, safe browser smoke, and ST22 delta. Review the plan before production changes.
-5. Implement the smallest change that turns the test green. Refactor only while the complete suite remains green. Edit source locally for source-only changes; create structural SAP objects in a development system and export them with native abapGit instead of inventing serializer XML.
+5. Implement the smallest change that turns the test green. Refactor only while the complete suite remains green. For frontend, database, authorization, or other environment-dependent assumptions, treat the first green implementation as a spike until a live integration test confirms it. Edit source locally for source-only changes; create structural SAP objects in a development system and export them with native abapGit instead of inventing serializer XML.
 6. Run `npm ci`, `npm test`, `git diff --check`, a complete diff review, and the relevant security/authorization review. Deploy the exact candidate to each available SAP target without pretending that the shared abapGit `master` link represents an unmerged branch.
-7. On SAP_BASIS 750 first when available, then S/4HANA 2023, require controlled activation, active syntax, all ABAP Unit tests, and complete ATC runs or explicit prerequisite failures. Run safe browser smoke and ST22 delta on A4H only. A failed/unavailable gate is never a pass.
+7. On SAP_BASIS 750 first when available, then S/4HANA 2023, require controlled activation, active syntax, all ABAP Unit tests, and complete ATC runs or explicit prerequisite failures. An ARC-1 write acknowledgement or `activate=true` request is not activation evidence: call activation explicitly, then require active/inactive object-state equality. Run a fresh-session safe browser smoke and ST22 delta on A4H only. A failed/unavailable gate is never a pass.
 8. Perform a final implementation review, update finding evidence, commit with a Conventional Commit subject, push the branch, open a pull request, and wait for required CI to become green.
 9. After the first green PR run, audit the plan, implementation, test evidence, CI output, and development process. Apply useful process/documentation improvements to the same PR, move its plan to `docs/plans/finished/`, push, and wait for CI again.
 10. Merge only after the maintainer accepts any recorded live-system limitations. Pull the resulting `master`, verify Release Please behavior, and do not manually tag an ordinary release.
 
 For a source-only candidate, a controlled direct source deployment is preferable to switching the shared native-abapGit repository away from `master`. Record the candidate commit/hash and activate only the intended object. Structural changes still require a real native-abapGit round trip and may need a dedicated package/system to avoid changing shared objects underneath other work.
+
+If ARC-1's pre-write linter selects the wrong ABAP release, bypass only that local lint step after the repository's pinned abaplint gate is green. Keep server preflight, explicit activation, SAP syntax, Unit, ATC, and object-state verification enabled, and record the tooling mismatch in the findings register.
 
 If ARC-1 authentication or a live system is unavailable, local checks may continue, but do not claim live validation. Record the missing gate in the PR and complete it before merge unless the maintainer explicitly accepts the risk.
 
@@ -50,6 +52,7 @@ NPL currently lacks ZTOAD's transparent table. SAP_BASIS 750 has no ADT transpar
 - Test both the success path and invalid/untrusted input. ZTOAD executes dynamic SQL, so authorization boundaries, dynamic table/column input, escaping, DML, and native SQL are security-sensitive.
 - ABAP Unit tests must not change customizing or persistent business data. Any integration test that writes must use an explicitly disposable Z table and be cleaned up.
 - Local abaplint is a fast compatibility/static gate, not a substitute for SAP syntax, activation, ABAP Unit, or ATC.
+- ABAP Unit and syntax cannot prove that a Control Framework class is supported by a particular frontend. GUI-control changes require a new browser session against the exact active candidate plus a post-run dump check.
 
 ## Live-system safety
 
@@ -59,6 +62,7 @@ NPL currently lacks ZTOAD's transparent table. SAP_BASIS 750 has no ADT transpar
 - Do not run destructive SQL merely to prove parsing. DML/native tests require an isolated table, explicit authorization, and a cleanup plan.
 - Resolve and record the ATC variant used on each system. Prefer the same effective checks on both systems.
 - Record whether an ATC run was complete. Zero displayed findings with missing prerequisite checks is incomplete, not a pass.
+- Before judging a UI product regression, verify the installed dynpro, GUI status, transaction, and other serialized prerequisites. Record installation drift as its own finding while keeping the overall end-to-end gate blocked.
 
 ## Files and release automation
 

--- a/docs/baseline-findings.md
+++ b/docs/baseline-findings.md
@@ -1,6 +1,6 @@
 # ZTOAD baseline findings
 
-_Snapshot: 2026-08-06 · branch `master` · local HEAD `cae4dea2062b` plus the uncommitted test/setup baseline · live system A4H client 001, SAP_BASIS 758 SP02_
+_Snapshot: 2026-08-06 · branch `codex/fix-base-run-001` · live system A4H client 001, SAP_BASIS 758 SP02 · secondary target NPL client 001, SAP_BASIS 750 SP02_
 
 This is the ordered work list for incremental TDD. It records observed defects separately from broad style debt so a new failure cannot disappear inside the legacy backlog. A finding is closed only after its regression test is green locally where possible, green on A4H, and green on the SAP_BASIS 750 target.
 
@@ -9,17 +9,17 @@ This is the ordered work list for incremental TDD. It records observed defects s
 | Gate | Result | Interpretation |
 |---|---|---|
 | Repository `npm test` | Passed, 0 configured abaplint findings | Fast compatibility/XML gate is green |
-| Pinned abaplint default profile | 1,857 findings across 57 rules on the current candidate | Existing debt; reproducible locally, not an immediate all-or-nothing gate |
+| Pinned abaplint default profile | 1,878 findings across 58 rules; `master` baseline 1,857 across 57 | Existing debt plus 19 adapter naming and 2 legacy exception-contract findings; reproducible locally, not an immediate all-or-nothing gate |
 | A4H SAP syntax | 0 errors, 4 warnings | Program compiles on SAP_BASIS 758 |
-| A4H ABAP Unit | 14 passed, 0 failed | Initial parser/command/line-splitting characterization baseline is green |
+| A4H ABAP Unit | 19 passed, 0 failed | Parser, generator, command, line-splitting, and editor-policy tests are green |
 | A4H ATC `S4HANA_READINESS_2023` | Initial run displayed 0 finding rows | Later evidence shows missing prerequisites; this is not an authoritative zero gate |
-| A4H ATC `ABAP_CLOUD_READINESS` | 758 findings: 466 priority 1, 292 priority 2 | Current classic report is not ABAP Cloud compatible |
-| A4H WebGUI smoke | Failed | New ST22 dump `RAISE_EXCEPTION` in `SAPLCNDP`, described by `BASE-RUN-001` |
-| ABAP 7.50 live gate | Not run | Separate ARC-1/abapGit destination is still required |
+| A4H ATC `ABAP_CLOUD_READINESS` | 768 findings: 463 priority 1, 305 priority 2 | Current classic report is not ABAP Cloud compatible |
+| A4H WebGUI smoke | Editor startup/input passed; query dispatch blocked | Final editor renders and accepts text without a new dump; installed GUI status `STATUS010` is missing (`BASE-BUG-007`) |
+| ABAP 7.50 live gate | ARC-1 lifecycle passed; ZTOAD blocked | `arc-1-750` can create/activate/syntax/unit/delete, but ZTOAD's transparent table is absent and SAP_BASIS 750 cannot create it over ADT |
 
-The four normal syntax warnings are POSIX-regex deprecation at lines 1668, 1691, and 1817, plus the unsupported `C_DB_EXECUTE` call at line 3818.
+The four normal syntax warnings on the BASE-RUN-001 candidate are POSIX-regex deprecation at lines 1965, 1988, and 2114, plus the unsupported `C_DB_EXECUTE` call at line 4118.
 
-The current `BASE-BUG-001` candidate passes 17/17 A4H ABAP Unit methods and keeps the same four normal syntax warnings. Its latest `ABAP_CLOUD_READINESS` result is 767 findings (466 P1, 301 P2); two P2 `FORM` warnings are in the new characterization helper, while the production fix adds none. The latest `S4HANA_READINESS_2023` run is incomplete because seven prerequisite checks are unavailable. See the [finished issue plan](plans/finished/base-bug-001.md) for exact evidence.
+The BASE-BUG-001 parser/generator baseline remains green inside the current 19-test suite. The current `ABAP_CLOUD_READINESS` result is 768 findings (463 P1, 305 P2). The latest `S4HANA_READINESS_2023` run returned no rows but is incomplete because seven prerequisite checks are unavailable. See the [finished BASE-BUG-001 plan](plans/finished/base-bug-001.md) and the [BASE-RUN-001 research](research/2026-08-06-base-run-001-webgui-editor-root-cause.md) for exact evidence.
 
 ## Ordered findings register
 
@@ -27,7 +27,7 @@ Priority meanings: **P0** blocks the requested test workflow or is an immediate 
 
 | ID | Pri. | Finding and evidence | Test to drive the fix | Status |
 |---|---:|---|---|---|
-| BASE-RUN-001 | P0 | ZTOAD dumps immediately in WebGUI/FLP. ST22 at 2026-08-06 05:52:14 UTC shows `DATA_SOURCE_ERROR` raised by `DP_PUBLISH_URL`, called from `CL_GUI_ABAPEDIT=>CONSTRUCTOR`, `EDITOR_INIT` line 1166. | Live WebGUI test: launch ZTOAD, assert the editor screen renders and ST22 has no new dump. Add an editor-factory unit seam before selecting a browser-safe fallback. | Open |
+| BASE-RUN-001 | P0 | ZTOAD originally dumped in WebGUI through `DP_PUBLISH_URL`; a rejected SQL-mode spike then dumped in `CL_GUI_SOURCEEDIT`. The final adapter uses `CL_GUI_TEXTEDIT` in WebGUI and keeps `CL_GUI_ABAPEDIT` elsewhere. | Two editor-policy Unit tests plus fresh WebGUI launch/input and post-run ST22 delta. | Fixed candidate: 19/19 green, editor renders and accepts input, no new dump; full query dispatch waits on `BASE-BUG-007` |
 | BASE-SEC-001 | P0 | User text becomes dynamic Open SQL and generated ABAP (`GENERATE SUBROUTINE POOL`, lines 2310 and 3657). Parser-derived table/field/tail tokens are not validated through a strict include list. | Malicious/ambiguous table, column, `WHERE`, `HAVING`, subquery, comment, and quoted-keyword cases; verify rejection before generation. | Open |
 | BASE-SEC-002 | P0 | Native SQL uses unsupported kernel call `C_DB_EXECUTE` at line 3818. It is a high-impact arbitrary database-command path and produces a live compiler warning. | Authorization-negative test, default-disabled test, allow-list test against a disposable Z object, and no-kernel-call architecture test. | Open |
 | BASE-SEC-003 | P0 | SELECT authorization extraction tokenizes top-level `FROM`/`JOIN` text and can miss nested subqueries/CTEs or concealed data sources. | Multi-table joins, nested subqueries, aliases, comments, quoted identifiers, UNION branches, and unauthorized inner-table cases. | Open |
@@ -37,7 +37,7 @@ Priority meanings: **P0** blocks the requested test workflow or is an immediate 
 | BASE-BUG-004 | P1 | Keyword detection uses string searches and space splitting rather than quote/parenthesis-aware lexical tokens. Keywords in literals, comments, functions, or subqueries can move clause boundaries. | Quoted `FROM`, `WHERE`, `UNION`, `UP TO`; escaped quotes; comments; nested parentheses; multiline queries. | Open |
 | BASE-BUG-005 | P1 | `UNION` splitting is whitespace-sensitive and does not model `UNION ALL`; branches are appended while assuming compatible result layouts. | `UNION`, `UNION ALL`, mismatched branch types/columns, per-branch limits, and keywords in literals/subqueries. | Open |
 | BASE-BUG-006 | P1 | [Issue #2](https://github.com/marianfoo/ztoad/issues/2): no serialized `TRAN ZTOAD` exists, so FLP/WebGUI cannot launch a stable ZTOAD transaction directly. | Native-abapGit round-trip on both systems plus direct FLP and standalone WebGUI launch tests. | Open |
-| BASE-BUG-007 | P1 | [Issue #5](https://github.com/marianfoo/ztoad/issues/5): source-only manual installation is incomplete; ZTOAD also needs dynpros/GUI status, TABL `ZTOAD`, and SUSO `ZTOAD_AUTH`. | Fresh-package native-abapGit install test verifying all objects activate and the first start reaches the editor. | Open |
+| BASE-BUG-007 | P1 | [Issue #5](https://github.com/marianfoo/ztoad/issues/5): source-only/manual installation is incomplete. A4H currently reaches screen 0010 but reports missing GUI status `STATUS010` even though repository `ztoad.prog.xml` serializes it; complete ZTOAD also needs its dynpros, TABL, and SUSO. | Fresh-package native-abapGit install test verifying all serialized objects and GUI metadata activate, `STATUS010` exists, and the first read-only query can be dispatched. | Open; currently blocks full A4H query smoke |
 | BASE-RUN-002 | P1 | Generated-program failures are not isolated into a stable error contract; dumps or generated source can leak query details. | Syntax/runtime exception tests with sanitized error output and no ST22 dump for expected bad input. | Open |
 | BASE-RUN-003 | P1 | The generated subroutine-pool approach has a finite per-session pool budget and encourages session restart behavior instead of bounded execution objects. | Repeated-query stress test across the documented maximum, checking graceful handling and cleanup. | Open |
 | BASE-RUN-004 | P1 | `UP TO 0 ROWS` means unlimited results. A user can accidentally run an unbounded query or expensive aggregation in an interactive tool. | Row-limit policy tests, explicit unlimited confirmation/policy test, timeout/load test on disposable data. | Open |
@@ -47,21 +47,24 @@ Priority meanings: **P0** blocks the requested test workflow or is an immediate 
 | BASE-ARCH-003 | P2 | Report-local ABAP Unit tests cannot be distributed separately, while an arbitrary second test report would lose native access/discovery. | Follow the [test-object extraction TODO](plans/test-object-extraction.md): extract cohesive global classes and move tests to native class test includes incrementally. | TODO |
 | BASE-CLEAN-001 | P2 | Clean-core status is provisionally Level D/unknown because of `CL_GUI_ABAPEDIT`, DDIC internals such as `DD03L`, system/kernel calls, and other unreleased references. Classic controls such as `CL_GUI_ALV_GRID` are Level B on-premise APIs. | Replace/encapsulate unsupported and unknown references, then re-run released-API ATC and document accepted Level B dependencies. | Open |
 | BASE-TOOL-001 | P2 | ARC-1 0.9.19 can list/check this native-abapGit repository but its clone call sends an XML shape rejected by A4H 758 (`repository` namespace mismatch). Native abapGit UI was required to link/pull. | Minimal ARC-1 integration reproduction against A4H 758; fix ARC-1 separately, keep UI fallback documented. | Open |
-| BASE-ENV-001 | P2 | The SAP_BASIS 750 target is not configured in this workspace, so the minimum-release promise is not yet proven for the new tests or future fixes. | Separate `arc-1-750` profile; pull `master`, activate, run syntax, Unit, ATC, and safe smoke suite. | Open |
+| BASE-ENV-001 | P2 | NPL and `arc-1-750` are configured and the ADT report lifecycle is proven, but exact ZTOAD validation is blocked because transparent table `ZTOAD` is absent and SAP_BASIS 750 has no ADT transparent-table create endpoint. | After the real table is provisioned outside the current ADT-only boundary, create/update the report and run activation, syntax, Unit, and ATC through ARC-1. NPL UI smoke is out of scope. | Partially complete; prerequisite blocked |
+| BASE-TOOL-002 | P2 | ARC-1 1.0.2 detects NPL release 750, but its lint inventory reports `v702`/unknown; absent `PROG ZTOAD` is misclassified as a class-local include, and nonexistent `DEVC ZTOAD` returns unrelated objects. | Add focused ARC-1 integration reproductions on NPL and correct release propagation, not-found hints, and package resolution in the ARC-1 project. | Open |
+| BASE-TOOL-003 | P2 | The local A4H ARC-1 pre-write linter also selected ABAP v702 and rejected valid 7.50+ syntax. The live SAP preflight accepted the exact source, and A4H activated it with zero syntax errors. | Propagate probed/configured SAP release into pre-write lint. Until fixed, bypass only `lintBeforeWrite` after repository abaplint is green; retain live preflight, explicit activation, syntax, Unit, and object-state checks. | Open |
 | BASE-REL-001 | P2 | Source declares 4.0.4 but the latest Git tag is 4.0.3. Release Please uses 4.0.4 as its manifest baseline, but its first compare link expects that tag. | After both live gates pass at an exact commit, decide whether to create the one-time immutable 4.0.4 tag/release. | Decision |
 | BASE-CTS-001 | P3 | Setup left empty local request `A4HK906377`; active work is in `A4HK906379`. | Manual owner decision whether to retain or delete the empty request. No automated deletion. | Decision |
 
 ## Full lint debt by rule
 
-This diagnostic profile is intentionally not the merge gate yet. Run `npm run lint:quality` to print the complete current per-rule list from the pinned CLI. New code must not add unexplained findings, and touched code should reduce relevant counts without mass-formatting unrelated lines. The counts, prioritization, and promotion-to-CI criteria are maintained in the [research report](research/2026-08-06-abaplint-quality-roadmap.md) and [active zero-findings plan](plans/abaplint-zero-findings.md).
+This diagnostic profile is intentionally not the merge gate yet. Run `npm run lint:quality` to print the complete current per-rule list from the pinned CLI. New code must not add unexplained findings, and touched code should reduce relevant counts without mass-formatting unrelated lines. The raw default profile contains a configuration conflict: `method_parameter_names` requires Hungarian-style direction/type prefixes while `no_prefixes` rejects those same prefixes. The future strict profile must resolve that conflict explicitly in favor of the selected Clean ABAP convention; suppressing individual findings just to lower the count is not acceptable. The counts, prioritization, and promotion-to-CI criteria are maintained in the [research report](research/2026-08-06-abaplint-quality-roadmap.md) and [active zero-findings plan](plans/abaplint-zero-findings.md).
 
 ## Initial executable tests
 
-The program now ends with four harmless, short ABAP Unit classes:
+The program now ends with five harmless, short ABAP Unit classes:
 
 - `LTC_QUERY_PARSER`: 8 tests for simple SELECT, default/explicit/unlimited limits, tail clauses, UNION separation, comma syntax, caller `INTO` removal, and missing `FROM` rejection.
 - `LTC_QUERY_GENERATOR`: 3 tests for strict aggregate clause ordering plus escaped-count and legacy-select compatibility.
 - `LTC_LINE_SPLITTER`: 3 tests for short lines, the 255-character boundary, and long-line splitting.
 - `LTC_COMMAND_PARSER`: 3 tests for UPDATE, DELETE FROM, and NATIVE quote conversion.
+- `LTCL_EDITOR_CONFIGURATION`: 2 tests selecting the supported WebGUI text editor while retaining the desktop ABAP editor.
 
 These are characterization tests: they make current behavior explicit without claiming that every behavior is correct. For each open bug, add the smallest failing regression test first, then implement the fix, then refactor while all earlier tests remain green.

--- a/docs/development.md
+++ b/docs/development.md
@@ -65,19 +65,21 @@ Do not manually install only the report source. That omits the dynpros, table, a
 `master` remains the only long-lived integration/release line and the normal branch of each shared native-abapGit link. Development uses a short-lived pull-request branch so CI and review can evaluate the candidate without placing an unreviewed state on `master`.
 
 1. Synchronize local `master`, create `codex/<finding-id>`, select one finding, and confirm the target systems have no unrelated differences.
-2. Research and reproduce the problem on the oldest available affected system. Check fixture availability before making a spike permanent.
+2. Research and reproduce the problem on the oldest available affected system. Check fixture and serialized UI-metadata availability before making a spike permanent.
 3. Add the smallest test, replay the original production code, and record the intended red failure.
 4. Write and review a plan under `docs/plans/` covering implementation, ABAP 7.50, Clean ABAP/Clean Core, local/live tests, rollback, browser smoke, and ST22.
-5. Edit source locally and make the smallest production change that turns the test green. Keep serializer XML unchanged for a source-only fix.
+5. Edit source locally and make the smallest production change that turns the test green. For a frontend or other environment-dependent assumption, keep the candidate classified as a spike until live integration evidence accepts it. Keep serializer XML unchanged for a source-only fix.
 6. Run `npm ci`, `npm test`, `git diff --check`, and the final local/security review.
-7. Deploy the exact candidate source to SAP_BASIS 750 first through ARC-1/ADT when its real dependencies exist; record any missing ADT prerequisite as blocked. Keep the A4H native-abapGit link on `master` and record an unmerged candidate as a direct deployment.
-8. On NPL, activate only the intended object and run active syntax, all ABAP Unit tests, and complete ATC variants through ARC-1. On A4H/SAP_BASIS 758, repeat those checks and additionally run safe browser smoke and ST22 delta.
+7. Deploy the exact candidate source to SAP_BASIS 750 first through ARC-1/ADT when its real dependencies exist; record any missing ADT prerequisite as blocked. Keep the A4H native-abapGit link on `master` and record an unmerged candidate as a direct deployment. Follow every write with an explicit activation call and active/inactive object-state comparison; a write response or activation option alone is not proof that the active version changed.
+8. On NPL, activate only the intended object and run active syntax, all ABAP Unit tests, and complete ATC variants through ARC-1. On A4H/SAP_BASIS 758, repeat those checks and additionally start a fresh browser session for safe smoke and ST22 delta. Verify required dynpros/GUI statuses before attributing an end-to-end failure to the source candidate.
 9. If a correction must be made in SAP, export it through native abapGit or reproduce it locally, then review every serialized/source difference. Never leave an unexported system-only fix.
 10. Perform a final review, update evidence, commit/push the short-lived branch, open the PR, and wait for CI. After the first green run, audit the process/CI, update guidance in the same PR, move the plan to `docs/plans/finished/`, push, and wait again.
 
 Always test 7.50 first when the destination and the candidate's real dependencies are available. A change that uses newer syntax may appear correct on 2023 yet be impossible to activate on the compatibility floor. The `arc-1-750` profile and ADT lifecycle are configured and proven; exact ZTOAD validation remains blocked while transparent table `ZTOAD` is absent because SAP_BASIS 750 cannot create transparent tables over ADT. See [the NPL dossier](research/2026-08-06-npl-adt-only-validation.md).
 
 Native abapGit branch switching changes real system objects, and abapGit Flow remains beta. Do not use either casually in the shared package. Structural-object PRs may require a dedicated package/system or an explicitly coordinated temporary branch procedure.
+
+If ARC-1's pre-write linter reports an incorrect ABAP release, do not weaken all write checks. After the pinned repository abaplint gate passes, disable only the mis-profiled local lint request, retain server preflight, activate explicitly, and run SAP syntax/Unit/ATC/object-state checks. Track the tool mismatch separately from the product change.
 
 ## 5. Structural object changes
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -15,7 +15,7 @@ Use each tool for the part it can represent faithfully:
 | abaplint | Fast local parsing, 7.50 syntax floor, and XML consistency | No; local preflight only |
 | ARC-1 | System discovery, dependency reads, object state, syntax, ABAP Unit, ATC, and controlled targeted writes | Authoritative for the connected live system |
 | ARC-1 source mirror | Searchable read-only snapshot | No; it does not contain all abapGit metadata |
-| ABAP 7.50 system | Minimum-release compile/runtime gate | Yes, for 7.50 behavior |
+| ABAP 7.50 NPL | ADT-only minimum-release activation, syntax, Unit, and ATC gate | Yes, when ZTOAD's real DDIC dependency is installed |
 | S/4HANA 2023 system | Current-platform compile/runtime gate | Yes, for 2023 behavior |
 
 The local repository and SAP systems must not diverge silently. Every system-side correction is exported through native abapGit and reviewed as a Git diff.
@@ -39,9 +39,9 @@ npm test
 
 `@abaplint/cli` is pinned exactly because the project does not claim semantic-version compatibility. The config uses abaplint's canonical release `v762`, which maps to on-premise SAP_BASIS 750. The initial rule set deliberately concentrates on parsing, syntax, type resolution, includes, method consistency, line endings, and abapGit XML consistency. It creates a zero-warning baseline for this legacy report. Add stricter rules only with the refactoring that resolves their existing findings.
 
-## 3. Native abapGit setup on each SAP system
+## 3. Native abapGit setup on the complete-object test system
 
-Use a separate native-abapGit repository link in each test system. The repository already declares `/src/` as its starting folder and `PREFIX` folder logic, so the root package name may differ per system.
+Use native abapGit on A4H for complete object round trips. The repository already declares `/src/` as its starting folder and `PREFIX` folder logic, so the root package name may differ per system. NPL is deliberately ARC-1/ADT-only: do not use its FLP, WebGUI, SAP GUI, or browser automation.
 
 For an isolated sandbox with no transport requirement, use a local package such as `$ZTOAD`. For a shared/transportable test package, use a customer package selected by the system owner and record its transport layer. A4H now uses transportable package `ZTOAD`, layer `ZDEV`, and request `A4HK906379`. Do not create a second clone in the same system: ABAP object names are system-global, so two ZTOAD work states cannot coexist under different packages.
 
@@ -70,12 +70,12 @@ Do not manually install only the report source. That omits the dynpros, table, a
 4. Write and review a plan under `docs/plans/` covering implementation, ABAP 7.50, Clean ABAP/Clean Core, local/live tests, rollback, browser smoke, and ST22.
 5. Edit source locally and make the smallest production change that turns the test green. Keep serializer XML unchanged for a source-only fix.
 6. Run `npm ci`, `npm test`, `git diff --check`, and the final local/security review.
-7. Deploy the exact candidate source to SAP_BASIS 750 first through a controlled ARC-1/editor write when available; keep the shared native-abapGit link on `master` and record that the candidate is a direct deployment.
-8. Activate only the intended object and run active syntax, all ABAP Unit tests, complete ATC variants, safe smoke, and ST22 delta. Repeat on A4H/SAP_BASIS 758.
+7. Deploy the exact candidate source to SAP_BASIS 750 first through ARC-1/ADT when its real dependencies exist; record any missing ADT prerequisite as blocked. Keep the A4H native-abapGit link on `master` and record an unmerged candidate as a direct deployment.
+8. On NPL, activate only the intended object and run active syntax, all ABAP Unit tests, and complete ATC variants through ARC-1. On A4H/SAP_BASIS 758, repeat those checks and additionally run safe browser smoke and ST22 delta.
 9. If a correction must be made in SAP, export it through native abapGit or reproduce it locally, then review every serialized/source difference. Never leave an unexported system-only fix.
 10. Perform a final review, update evidence, commit/push the short-lived branch, open the PR, and wait for CI. After the first green run, audit the process/CI, update guidance in the same PR, move the plan to `docs/plans/finished/`, push, and wait again.
 
-Always test 7.50 first when the destination is available. A change that uses newer syntax may appear correct on 2023 yet be impossible to deserialize or activate on the compatibility floor. Until the 7.50 ARC-1 profile is configured, this is a recorded missing gate rather than a pass.
+Always test 7.50 first when the destination and the candidate's real dependencies are available. A change that uses newer syntax may appear correct on 2023 yet be impossible to activate on the compatibility floor. The `arc-1-750` profile and ADT lifecycle are configured and proven; exact ZTOAD validation remains blocked while transparent table `ZTOAD` is absent because SAP_BASIS 750 cannot create transparent tables over ADT. See [the NPL dossier](research/2026-08-06-npl-adt-only-validation.md).
 
 Native abapGit branch switching changes real system objects, and abapGit Flow remains beta. Do not use either casually in the shared package. Structural-object PRs may require a dedicated package/system or an explicitly coordinated temporary branch procedure.
 
@@ -118,7 +118,7 @@ CLASS ltc_query_parser DEFINITION
 ENDCLASS.
 ```
 
-The baseline now contains 17 live-passing characterization tests across `LTC_QUERY_PARSER`, `LTC_QUERY_GENERATOR`, `LTC_LINE_SPLITTER`, and `LTC_COMMAND_PARSER`. The next regression corpus should cover the existing open parser reports:
+The baseline now contains 19 live-passing tests across `LTC_QUERY_PARSER`, `LTC_QUERY_GENERATOR`, `LTC_LINE_SPLITTER`, `LTC_COMMAND_PARSER`, and `LTCL_EDITOR_CONFIGURATION`. The next regression corpus should cover the existing open parser reports:
 
 - aggregate functions around `CASE` (issue #7)
 - SQL string functions such as `SUBSTRING` and `CONCAT` (issue #4)
@@ -137,8 +137,8 @@ Run these checks for the complete ZTOAD object set on both systems:
 2. All imported objects activate.
 3. SAP syntax check passes for program `ZTOAD`.
 4. ABAP Unit passes with no skipped relevant tests.
-5. ATC completes with the recorded project variants and has no new unapproved finding. The latest A4H `S4HANA_READINESS_2023` browser run displayed no finding rows but was incomplete because seven prerequisite checks are unavailable. The latest `ABAP_CLOUD_READINESS` run reported 767 architectural findings (466 P1, 301 P2); it is an information/burn-down signal, not a zero gate. The older 758 count remains historical baseline evidence, not a substitute for a complete current run.
-6. Manual read-only smoke tests pass.
+5. ATC completes with the recorded project variants and has no new unapproved finding. The latest A4H `S4HANA_READINESS_2023` run returned no finding rows but was incomplete because seven prerequisite checks are unavailable. The latest `ABAP_CLOUD_READINESS` run reported 768 architectural findings (463 P1, 305 P2); it is an information/burn-down signal, not a zero gate.
+6. Manual read-only browser smoke tests pass on A4H; NPL UI smoke is not applicable by maintainer direction.
 7. Authorization-negative tests confirm that unauthorized tables/activities remain blocked.
 8. ST22 and, when relevant, Gateway/system logs contain no new errors from the test.
 
@@ -165,9 +165,9 @@ SELECT SINGLE mandt FROM t000
 
 Then exercise the parser feature being changed with a sanitized query and verify both the generated source and result. Never use INSERT, UPDATE, DELETE, or native SQL against SAP/business tables for smoke testing. Such tests are permitted only against an isolated disposable Z table with explicit authorization.
 
-The current A4H WebGUI smoke is not green: startup dumps in `CL_GUI_ABAPEDIT=>CONSTRUCTOR` (`BASE-RUN-001`). Do not report browser E2E as passed until that finding is fixed and the post-run ST22 check is clean.
+`BASE-RUN-001` is fixed at the editor boundary: a fresh A4H WebGUI launch renders the fallback editor, accepts the sanitized query, and creates no new ST22 dump. Full query execution is still not green because the current A4H installation lacks GUI status `STATUS010` (`BASE-BUG-007`). Keep product behavior failures separate from incomplete system metadata, and never run this browser protocol on NPL.
 
-Use `npm run lint:quality` to reproduce the non-blocking full default-rule inventory. Its current 1,857 findings are reduced through [the active zero-findings plan](plans/abaplint-zero-findings.md); only promote `npm run lint:quality -- --strict` to required CI after it is green.
+Use `npm run lint:quality` to reproduce the non-blocking full default-rule inventory. `master` has 1,857 findings; the BASE-RUN-001 candidate has 1,878, with 19 adapter-API naming diagnostics plus 2 classic-exception diagnostics needed to preserve the legacy Control Framework `sy-subrc` contract. The raw defaults contain conflicting prefix/no-prefix naming rules, so the strict profile must resolve that configuration conflict explicitly while the raw inventory remains visible. Continue the [active zero-findings plan](plans/abaplint-zero-findings.md); only promote the resolved strict command to required CI after it is green.
 
 ## 8. Security review for every parser/execution change
 

--- a/docs/plans/abaplint-zero-findings.md
+++ b/docs/plans/abaplint-zero-findings.md
@@ -1,28 +1,30 @@
 # Plan: reduce the full abaplint inventory to zero
 
-_Status: active · Baseline: 1,857 findings in 57 default rules on 2026-08-06_
+_Status: active · Raw `master` baseline: 1,857 findings in 57 default rules on 2026-08-06_
 
 ## Goal
 
-Reach zero findings under the pinned abaplint default rules without changing intended ZTOAD behavior, then promote the strict full-quality command to required pull-request CI.
+Reach zero findings under a pinned, internally coherent strict abaplint profile without changing intended ZTOAD behavior, then promote that profile to required pull-request CI. Keep the raw default-rule inventory reproducible as a broad discovery report, but do not define an impossible gate from mutually contradictory default configurations.
 
 ## Guardrails
 
 - Keep `npm test` as the current zero-finding compatibility/XML merge gate.
 - Use `npm run lint:quality` to recreate the full diagnostic list; do not add its nonzero result to CI yet.
+- Resolve rule-configuration contradictions explicitly and document the selected Clean ABAP convention. In particular, the defaults for `method_parameter_names` require Hungarian prefixes while `no_prefixes` rejects the same prefixes; the strict profile should keep the no-prefix convention and configure or remove the redundant conflicting naming rule.
 - Never bulk-fix behavior-sensitive rules without characterization tests.
 - Keep one issue/one coherent rule batch per pull request and review generated SQL, authorization, data access, and GUI behavior separately.
 - Do not suppress findings solely to lower the count.
 
 ## Work packages
 
-1. Capture a machine-readable baseline and add a comparison command that fails only on newly introduced findings.
-2. Resolve parser errors and prove ABAP 7.50/live syntax parity.
-3. Address dangerous statements, SQL escaping/strictness, authorization paths, unchecked return codes, and database-loop findings with security-focused tests.
-4. Follow the [test-object extraction TODO](test-object-extraction.md): extract parser, generator, authorization, and editor boundaries into classes and move their tests to native class test includes.
-5. Remove obsolete and ambiguous constructs in small reviewed batches.
-6. Apply mechanical formatting/naming batches last, with no functional changes.
-7. When `npm run lint:quality -- --strict` is green locally and on both SAP targets, add it to `.github/workflows/quality.yml` and make the check required.
+1. Capture a machine-readable raw baseline and add a comparison command that reports newly introduced findings without pretending contradictory naming defaults can reach zero.
+2. Define and review the coherent strict profile, selecting Clean ABAP no-prefix naming and documenting every deviation from raw defaults.
+3. Resolve parser errors and prove ABAP 7.50/live syntax parity.
+4. Address dangerous statements, SQL escaping/strictness, authorization paths, unchecked return codes, and database-loop findings with security-focused tests.
+5. Follow the [test-object extraction TODO](test-object-extraction.md): extract parser, generator, authorization, and editor boundaries into classes and move their tests to native class test includes.
+6. Remove obsolete and ambiguous constructs in small reviewed batches.
+7. Apply mechanical formatting/naming batches last, with no functional changes.
+8. When the coherent strict command is green locally and on both SAP targets, add it to `.github/workflows/quality.yml` and make the check required.
 
 ## Required evidence per batch
 

--- a/docs/plans/base-run-001.md
+++ b/docs/plans/base-run-001.md
@@ -1,0 +1,76 @@
+# BASE-RUN-001 implementation and validation plan
+
+_Status: implemented and validated; pull request pending · branch: `codex/fix-base-run-001`_
+
+## Goal and root cause
+
+Make ZTOAD reach a usable query editor in A4H WebGUI without creating a new ST22 dump. The original failure is the default `ABAP` source type passed implicitly to `CL_GUI_ABAPEDIT`; its constructor publishes lexer data through `DP_PUBLISH_URL`, which raises an uncaught `DATA_SOURCE_ERROR`. A live spike additionally proved that the underlying source-editor control has no valid WebGUI frontend handle even when lexer publication is skipped. Full evidence is in [the root-cause report](../research/2026-08-06-base-run-001-webgui-editor-root-cause.md).
+
+## Test-first change
+
+1. Add a pure `LCL_EDITOR_CONFIGURATION` policy with an injected `WEBGUI` flag.
+2. First implement the legacy behavior (`ABAP` for every GUI) and add two harmless, short tests:
+   - WebGUI expects `TEXT` so the new regression test is red on the original behavior.
+   - non-WebGUI expects `ABAP` so desktop behavior is characterized.
+3. Deploy that exact red candidate to A4H, activate it, and record that only the focused WebGUI test fails for the intended reason.
+4. Spike the smallest plausible fallback, validate it in the live browser, and reject it if it only moves the dump.
+5. Introduce a narrow adapter that uses `CL_GUI_TEXTEDIT` in WebGUI and `CL_GUI_ABAPEDIT` elsewhere.
+6. Keep the full suite green while mapping only the common operations used by ZTOAD.
+
+## Compatibility and design review
+
+- The change uses syntax and released language features available on SAP_BASIS 750.
+- It does not change serialized dynpros, DDIC objects, authorization behavior, query parsing, generated SQL, or persistence.
+- The pure policy separates the environment decision from Control Framework construction and is readable without frontend test infrastructure.
+- The adapter encapsulates the unavoidable control difference instead of spreading WebGUI conditionals through application code.
+- Windows/Java GUI retains the ABAP editor, F1 help, completion, quick info, insert-pattern events, and drag/drop.
+- WebGUI uses its supported plain text editor and intentionally omits source-editor-only enhancements.
+- `CL_GUI_CONTROL=>WWW_ACTIVE` is the release-local standard signal used throughout SAP's own `CL_GUI_FRONTEND_SERVICES` implementation for SAP GUI for HTML.
+- The classic Control Framework remains an on-premise Level-B dependency. This fix removes one unsupported runtime assumption but does not claim ABAP Cloud compatibility.
+
+## Validation matrix
+
+### Local
+
+- `npm ci`
+- `npm test`
+- `npm run lint:quality` and compare total/per-rule counts; do not add unexplained debt
+- `git diff --check`
+- review source and serializer diff; only report source and documentation should change
+- security review: no SQL, authorization, persistence, or credential boundary changes
+
+### NPL SAP_BASIS 750
+
+- Use ARC-1/ADT only; do not use FLP, WebGUI, SAP GUI, or browser automation.
+- If the real transparent table `ZTOAD` is present: deploy the exact report source, activate, run syntax, all ABAP Unit tests, and ATC.
+- If the table remains absent: record the exact ADT transparent-table prerequisite as a blocked gate. Do not replace it with a structure and do not report a pass.
+- UI smoke and ST22 are not applicable on NPL by maintainer direction.
+
+### A4H SAP_BASIS 758
+
+- Record active/inactive state and pre-test ST22 timestamp.
+- Deploy the exact candidate source through ARC-1, activate, run syntax and all ABAP Unit tests.
+- Run the recorded ATC variants and distinguish incomplete prerequisite runs from passes.
+- Launch ZTOAD through the supported HTTPS WebGUI/FLP path.
+- Confirm the editor renders, enter the sanitized read-only query `SELECT SINGLE mandt FROM t000`, and verify the expected result path.
+- Re-read ST22 and require no new ZTOAD-related dump.
+
+## Evidence recorded before the pull request
+
+- Red candidate on A4H: 18 passed, only the focused WebGUI policy test failed.
+- Rejected SQL-source-type spike: all 19 Unit tests passed, but live WebGUI produced `RAISE_EXCEPTION` in `CL_GUI_SOURCEEDIT` at `2026-08-06T09:30:59Z`; the candidate was not accepted.
+- Final adapter: `npm ci`, `npm test`, and `git diff --check` pass.
+- Diagnostic full-rule inventory: 1,878 findings versus 1,857 on `master`; 19 additions expose a conflict between default parameter-prefix and no-prefix rules, and 2 classic-exception diagnostics preserve the legacy control-error/`sy-subrc` contract.
+- A4H exact active source: no inactive divergence, 0 syntax errors, the same 4 known warnings, and 19/19 Unit tests green.
+- A4H ATC: 768 cloud-readiness findings (463 P1, 305 P2); S/4HANA-readiness returned no rows but remains prerequisite-incomplete.
+- Fresh WebGUI launch after activation: editor rendered and accepted the read-only query; no new ST22 dump.
+- Result execution could not be tested because A4H lacks installed GUI status `STATUS010`, an independent `BASE-BUG-007` prerequisite despite its presence in repository XML.
+- NPL: ADT-only connection/lifecycle usable; exact ZTOAD gate blocked by absent transparent table and unavailable 7.50 ADT table-create endpoint.
+
+## Rollback
+
+Restore the original report source from `master` through ARC-1 and reactivate. No database or structural-object rollback is required. If the WebGUI editor renders but loses an essential interaction, revert rather than broadening the same PR into an editor rewrite.
+
+## Final review and PR
+
+After all available gates, review the complete diff and evidence, update `BASE-RUN-001`, commit with a Conventional Commit subject, push, open a PR, and wait for required CI. After its first green run, audit the workflow and CI, apply useful documentation/process improvements in the same PR, move this plan to `docs/plans/finished/`, push, and wait for green again. Do not merge without maintainer direction, especially while the 7.50 ZTOAD gate is blocked.

--- a/docs/plans/finished/base-run-001.md
+++ b/docs/plans/finished/base-run-001.md
@@ -1,10 +1,10 @@
 # BASE-RUN-001 implementation and validation plan
 
-_Status: implemented and validated; pull request pending · branch: `codex/fix-base-run-001`_
+_Status: completed in PR [#16](https://github.com/marianfoo/ztoad/pull/16) · branch: `codex/fix-base-run-001` · first CI run green_
 
 ## Goal and root cause
 
-Make ZTOAD reach a usable query editor in A4H WebGUI without creating a new ST22 dump. The original failure is the default `ABAP` source type passed implicitly to `CL_GUI_ABAPEDIT`; its constructor publishes lexer data through `DP_PUBLISH_URL`, which raises an uncaught `DATA_SOURCE_ERROR`. A live spike additionally proved that the underlying source-editor control has no valid WebGUI frontend handle even when lexer publication is skipped. Full evidence is in [the root-cause report](../research/2026-08-06-base-run-001-webgui-editor-root-cause.md).
+Make ZTOAD reach a usable query editor in A4H WebGUI without creating a new ST22 dump. The original failure is the default `ABAP` source type passed implicitly to `CL_GUI_ABAPEDIT`; its constructor publishes lexer data through `DP_PUBLISH_URL`, which raises an uncaught `DATA_SOURCE_ERROR`. A live spike additionally proved that the underlying source-editor control has no valid WebGUI frontend handle even when lexer publication is skipped. Full evidence is in [the root-cause report](../../research/2026-08-06-base-run-001-webgui-editor-root-cause.md).
 
 ## Test-first change
 
@@ -74,3 +74,20 @@ Restore the original report source from `master` through ARC-1 and reactivate. N
 ## Final review and PR
 
 After all available gates, review the complete diff and evidence, update `BASE-RUN-001`, commit with a Conventional Commit subject, push, open a PR, and wait for required CI. After its first green run, audit the workflow and CI, apply useful documentation/process improvements in the same PR, move this plan to `docs/plans/finished/`, push, and wait for green again. Do not merge without maintainer direction, especially while the 7.50 ZTOAD gate is blocked.
+
+## Post-green process and CI audit
+
+PR #16's first Quality run, [31091738961](https://github.com/marianfoo/ztoad/actions/runs/31091738961), completed successfully. The pinned checkout/setup actions, Node.js 24, `npm ci`, and `npm test` all completed without warnings or dependency failures. The GitHub token is read-only and the job finished in eight seconds. The external abaplint check passed; its observations check completed neutral as expected.
+
+No CI workflow change is justified in this PR. The current configured compatibility/XML gate is green and appropriate. The raw full-quality inventory is intentionally not promoted because it still contains legacy debt and mutually contradictory default naming configurations; the active zero-findings plan now requires a coherent Clean ABAP strict profile before CI promotion.
+
+The audit produced these repository-process improvements:
+
+- Environment-dependent green candidates remain spikes until a live integration test accepts them. This prevented the SQL-source-type workaround from being shipped after it merely moved the dump.
+- ARC-1 write success and an `activate=true` option are not activation evidence. The workflow now requires explicit activation followed by active/inactive object-state equality.
+- GUI-control changes require a fresh browser session against the exact active source and a post-run ST22 delta; Unit and syntax checks alone are insufficient.
+- UI smoke now verifies serialized dynpro/GUI-status prerequisites before attributing a failure to product source. Missing `STATUS010` remains a separate `BASE-BUG-007` finding while keeping full query execution blocked.
+- When ARC-1's pre-write lint profile is wrong, only that local lint request may be bypassed after repository abaplint passes; live preflight, activation, syntax, Unit, ATC, and object-state checks remain mandatory.
+- NPL remains an ADT/ARC-1-only target. Its unavailable transparent-table creation prerequisite is recorded as blocked rather than replaced by an invalid DDIC substitute.
+
+These changes were added to `AGENTS.md`, the development playbook, the test strategy, and the abaplint zero-findings plan in the same PR.

--- a/docs/research/2026-08-06-base-run-001-webgui-editor-root-cause.md
+++ b/docs/research/2026-08-06-base-run-001-webgui-editor-root-cause.md
@@ -1,0 +1,91 @@
+# BASE-RUN-001: WebGUI editor startup dump
+
+_Research date: 2026-08-06 · affected system: A4H client 001, SAP_BASIS 758 SP02_
+
+## Reproduction and original evidence
+
+Launching ZTOAD in WebGUI reaches screen 0010 and terminates during `EDITOR_INIT`. The latest original pre-fix dump for user MARIAN is `RAISE_EXCEPTION` at `2026-08-06T07:56:39Z` in program `SAPLCNDP`.
+
+The active-call chain is:
+
+1. `ZTOAD` `EDITOR_INIT`
+2. `CL_GUI_ABAPEDIT=>CONSTRUCTOR`
+3. function module `DP_PUBLISH_URL`
+4. `DATA_SOURCE_ERROR` raised from `CL_DATAPROVIDER=>NOCACHE_SYNC`
+
+This is an uncaught classic exception inside the control constructor, so wrapping later editor method calls cannot recover startup.
+
+## Root cause
+
+The active A4H implementation of `CL_GUI_ABAPEDIT=>CONSTRUCTOR` calls its superclass and sets the requested source type. With the default source type `ABAP`, it unconditionally calls `DP_PUBLISH_URL` for namespace `LEXER_DATA`, installs a data-provider handler, and asks the frontend to load the ABAP lexer file. ZTOAD used the default and therefore selected this branch.
+
+WebGUI marks the session through `CL_GUI_CONTROL=>WWW_ACTIVE`. SAP's own frontend-services source treats that flag as SAP GUI for HTML. In the failing request, the data provider has no usable cache and synchronous publication raises `DATA_SOURCE_ERROR`.
+
+The deeper constraint is that the ABAP/source editor control is not usable in this WebGUI runtime. `CL_GUI_ABAPEDIT` suppresses superclass construction exceptions and continues. Avoiding only lexer publication can therefore leave a source-editor instance whose frontend handle was never created.
+
+## TDD and spike sequence
+
+The environment choice was first extracted into pure local class `LCL_EDITOR_CONFIGURATION`, allowing the frontend policy to be tested without constructing GUI controls.
+
+### Red evidence
+
+The legacy policy returned `ABAP` for every frontend. The focused WebGUI test expected the fallback and failed while all 18 pre-existing tests passed. This exact red candidate was activated and run on A4H, proving that the new test failed for the intended reason rather than because of a local-only test assumption.
+
+### Rejected first green candidate
+
+The first candidate returned source type `SQL` in WebGUI and kept `CL_GUI_ABAPEDIT`. It passed local abaplint, live syntax, and all 19 ABAP Unit tests, but the integration spike produced a different dump at `2026-08-06T09:30:59Z`:
+
+- error: `RAISE_EXCEPTION`
+- program: `CL_GUI_SOURCEEDIT=============CP`
+- failing operation: `REGISTER_EVENT_COMPLETION`
+- detail: `CNTL_ERROR` with an initial `h_control`
+- caller: ZTOAD `EDITOR_INIT`
+
+This disproved the assumption that changing the lexer type was sufficient. It skipped the original `DP_PUBLISH_URL` failure but retained an unsupported source-editor control.
+
+### Final candidate
+
+The final design introduces `LCL_EDITOR`, a narrow adapter over the two controls:
+
+- WebGUI (`CL_GUI_CONTROL=>WWW_ACTIVE`) creates `CL_GUI_TEXTEDIT`.
+- SAP GUI for Windows/Java creates `CL_GUI_ABAPEDIT` and retains F1 help, completion, quick info, insert-pattern events, and drag/drop.
+- The adapter exposes only the text, selection, modification-status, visibility, insertion, and focus operations used by ZTOAD.
+- WebGUI deliberately omits ABAP-editor-only F1/completion/drag-drop features because their control is unsupported there.
+- `LCL_EDITOR_CONFIGURATION` returns `TEXT` for WebGUI and `ABAP` elsewhere; both branches have harmless, short ABAP Unit tests.
+
+The change does not touch parsing, generated SQL, authorization, persistence, dynpros, or serialized repository metadata.
+
+## Final validation evidence
+
+### Local
+
+- `npm ci`: passed; 0 dependency vulnerabilities.
+- `npm test`: passed with 0 configured abaplint findings.
+- `git diff --check`: passed.
+- Full diagnostic inventory: 1,878 findings across 58 rules, compared with 1,857 across 57 on `master`. Nineteen explained additions are naming diagnostics for the new adapter API; two are classic-exception diagnostics retained to preserve the existing Control Framework `sy-subrc` error contract. The default profile simultaneously requires Hungarian-style method parameter prefixes and rejects those prefixes through `no_prefixes`; no suppression was added to manipulate the count.
+
+### NPL SAP_BASIS 750
+
+NPL was used only through ARC-1/ADT. Its connection and disposable report lifecycle are proven, but exact ZTOAD activation remains blocked because transparent table `ZTOAD` is absent and SAP_BASIS 750 has no ADT transparent-table creation endpoint. No substitute structure was created and no 7.50 pass is claimed. See [the NPL validation dossier](2026-08-06-npl-adt-only-validation.md).
+
+### A4H SAP_BASIS 758
+
+- Exact final source activated; active and inactive SHA-256 values match with no divergence.
+- SAP syntax: 0 errors, the same 4 known warnings (3 POSIX deprecations and unsupported `C_DB_EXECUTE`).
+- ABAP Unit: 19 passed, 0 failed, including both editor-policy tests.
+- ATC `ABAP_CLOUD_READINESS`: 768 findings (463 priority 1, 305 priority 2); architectural debt inventory, not a zero gate.
+- ATC `S4HANA_READINESS_2023`: no finding rows returned, but the known missing prerequisite checks make this non-authoritative.
+- Fresh standalone WebGUI launch after final activation: screen 0010 and the plain text editor rendered; `SELECT SINGLE mandt FROM t000` could be entered.
+- Post-smoke ST22: no new dump; the newest entry remains the rejected intermediate spike at `2026-08-06T09:30:59Z`.
+
+The query could not be dispatched because A4H reports `Status STATUS010 der Oberfläche ZTOAD fehlt`. The repository's `ztoad.prog.xml` contains `STATUS010`, so this is installation/metadata drift covered by `BASE-BUG-007`, not an editor-startup regression. `BASE-RUN-001` is therefore fixed at its editor startup/render/input boundary; complete query execution remains blocked by the separate structural-installation finding.
+
+## SAP guidance used
+
+SAP's ABAP documentation describes Control Framework classes as wrappers for GUI controls and recommends separating presentation, application, and persistence concerns in classic dynpro applications. The active standard-class implementations on A4H provide the release-exact behavior used for this diagnosis. No matching corrective SAP Note for this exact `CL_GUI_ABAPEDIT`/`DP_PUBLISH_URL` failure was found by the SAP Notes search.
+
+References:
+
+- [SAP ABAP documentation: Control Framework](https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABENCONTROL_FRAMEWORK_GLOSRY.html)
+- [SAP ABAP programming guideline: separation behind class interfaces](https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABENENCAP_CLASS_INTERF_GUIDL.html)
+- [SAP ABAP documentation: custom controls](https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABENDYNPRO_CUSTOM_CONTROLS.html)

--- a/docs/research/2026-08-06-npl-adt-only-validation.md
+++ b/docs/research/2026-08-06-npl-adt-only-validation.md
@@ -1,0 +1,47 @@
+# NPL SAP_BASIS 750 ADT-only validation target
+
+_Research date: 2026-08-06 · system: NPL client 001 · interface: ARC-1 over ADT only_
+
+## Decision and scope
+
+NPL is the minimum-release compiler and ABAP Unit target for ZTOAD. Per maintainer direction, it is not used for FLP, WebGUI, SAP GUI, or browser automation. All NPL operations must use ARC-1 and ADT APIs. Browser smoke testing remains an A4H/SAP_BASIS 758 responsibility.
+
+The separate Codex MCP profile is named `arc-1-750`. It is pinned to the published ARC-1 1.0.2 CLI, identifies the destination as on-premise SAP_BASIS 750, permits controlled writes only to the ZTOAD test package allowlist, and keeps data preview and free SQL disabled. Credentials remain outside the repository.
+
+## Live discovery
+
+ARC-1 authenticated as the configured NPL developer and reported:
+
+| Component | Release | SP |
+|---|---:|---:|
+| SAP_BASIS | 750 | 02 |
+| SAP_ABA | 750 | 02 |
+| SAP_UI | 750 | 02 |
+| SAP_GWFND | 750 | 02 |
+
+HANA, classic CTS, CDS, RAP, and UI5 endpoints are present. Native abapGit ADT integration and gCTS are unavailable. These missing integrations do not prevent source activation, syntax checks, or ABAP Unit through ADT.
+
+## Usability proof
+
+A disposable `$TMP` report, `ZARC1_ZTOAD_750_PROBE`, was created through `SAPWrite`, activated, syntax-checked, and executed with `SAPDiagnose action=unittest`. Its harmless, short unit test passed. The report was then deleted and its absence confirmed. This proves the ARC-1 read/write/activate/syntax/unit/cleanup lifecycle without SAP GUI or browser access.
+
+## ZTOAD deployment blocker
+
+Program `ZTOAD` and transparent table `ZTOAD` are not installed on NPL. The report cannot be compiled faithfully without the table because its source contains typed references and Open SQL operations against `ZTOAD`.
+
+SAP_BASIS 750 does not expose the ADT transparent-table create endpoint `/sap/bc/adt/ddic/tables`; that editor endpoint is available only on newer releases. The 7.50 structures endpoint must not be used as a substitute: it would create an internal structure rather than a transparent table and would make the validation result invalid. ARC-1 correctly refuses this unsafe write. This limitation is independently documented and live-probed in the ARC-1 research dossier `docs/research/2026-07-29-nw750-fixture-create-surface.md` in the ARC-1 repository.
+
+Therefore:
+
+- the NPL connection and source/unit lifecycle are usable;
+- exact ZTOAD activation, syntax, Unit, and ATC remain blocked until transparent table `ZTOAD` is provisioned once by a mechanism outside the maintainer's current ADT-only boundary;
+- no gate is reported as passed from a stub structure or partial source;
+- after the real table exists, ARC-1 can create/update the report, activate it, and run syntax, ABAP Unit, and ATC entirely through ADT.
+
+## Tooling observations
+
+- ARC-1 1.0.2 detects SAP_BASIS 750 correctly, but `SAPLint list_rules` reports an on-premise `v702` syntax profile with an unknown ABAP version. Repository abaplint and the live SAP compiler remain authoritative until ARC-1 aligns that preset.
+- `SAPRead PROG ZTOAD` returned a misleading class-local-test-include hint for an absent report.
+- `SAPRead DEVC ZTOAD` returned unrelated package contents for a nonexistent package. Do not use that response as installation evidence; use exact object reads/searches.
+
+These are ARC-1 quality findings, not ZTOAD product failures. They should be considered when interpreting automated bootstrap output.

--- a/docs/setup-evaluation.md
+++ b/docs/setup-evaluation.md
@@ -21,7 +21,7 @@ _Prepared 2026-08-06 from repository inspection, open GitHub issues, SAP Docs MC
 
 ### 1. Exact ATC variant on ABAP 7.50
 
-A4H currently has an incomplete `S4HANA_READINESS_2023` browser run: no finding rows were displayed, but seven prerequisite checks are unavailable. `ABAP_CLOUD_READINESS` currently reports 767 findings (466 P1, 301 P2). The recorded 758 result remains historical baseline evidence. The Cloud variant proves the classic report is not ABAP Cloud compatible and is retained as an architectural burn-down signal, not a zero gate.
+A4H currently has an incomplete `S4HANA_READINESS_2023` run: no finding rows were returned, but seven prerequisite checks are unavailable. On the BASE-RUN-001 candidate, `ABAP_CLOUD_READINESS` reports 768 findings (463 P1, 305 P2). Earlier 758/767 results remain historical evidence. The Cloud variant proves the classic report is not ABAP Cloud compatible and is retained as an architectural burn-down signal, not a zero gate.
 
 The matching SAP_BASIS 750 variant remains open because that destination is not configured. Recommendation: inventory the available 7.50 variants, select the closest effective security/performance/syntax set, and document differences rather than assuming identical names mean identical checks.
 
@@ -95,4 +95,4 @@ The pinned local default inventory is 1,857 findings across 57 rules. `npm run l
 | #2 Transaction code | Requires a serialized `TRAN` object, not only source. | Create it in SAP, export through native abapGit, and validate on both systems. |
 | #5 Manual installation | Source-only copying is incomplete because the report has dynpros/table/auth metadata. | Native-abapGit installation is now verified; document the WebGUI startup defect separately from installation. |
 
-The setup also discovered `BASE-RUN-001`: WebGUI/FLP startup dumps in `CL_GUI_ABAPEDIT`. See [baseline-findings.md](baseline-findings.md) for the complete ordered register and evidence. No existing GitHub issue was closed and no production bug fix was made during baseline characterization.
+The setup also discovered `BASE-RUN-001`: WebGUI startup dumped in `CL_GUI_ABAPEDIT`. The later BASE-RUN-001 candidate fixes editor startup/render/input without a new ST22 dump; full query dispatch is independently blocked by missing installed GUI status `STATUS010` (`BASE-BUG-007`). See [baseline-findings.md](baseline-findings.md) for the complete ordered register and current evidence. No existing GitHub issue was closed during the original baseline characterization.

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -26,8 +26,8 @@ For every bug or feature:
 | ATC | Security, performance, released API, and migration checks | Both SAP targets | Every `src/` change |
 | Native-abapGit check | Complete object serialization and remote/local consistency | Both SAP targets | Every structural/deployment change |
 | Integration test | DB/auth/executor behavior against disposable objects | Dedicated test client only | Parser/execution/security changes |
-| WebGUI/FLP smoke | Startup, controls, basic read-only query, navigation | A4H and later 7.50 if supported | UI/startup changes and release candidates |
-| ST22/log check | Detect uncaught regressions even if the browser returns to SAP Easy Access | Both SAP targets | Every live smoke test |
+| WebGUI/FLP smoke | Startup, controls, basic read-only query, navigation | A4H only | UI/startup changes and release candidates |
+| ST22/log check | Detect uncaught regressions even if the browser returns to SAP Easy Access | A4H | Every live browser smoke test |
 
 ## Unit-test design rules
 
@@ -58,6 +58,8 @@ Each parser/generator change should select relevant cases from this matrix:
 
 ## Live test protocol
 
+NPL/SAP_BASIS 750 is ARC-1/ADT-only. Run activation, syntax, ABAP Unit, and ATC there; do not use FLP, WebGUI, SAP GUI, or browser automation. If a required object cannot be installed through the available ADT surface, record a blocked prerequisite rather than using an unfaithful substitute.
+
 For A4H, use only the HTTPS reverse proxy:
 
 - FLP: `https://a4h.marianzeis.de/sap/bc/ui2/flp?sap-client=001#Shell-startGUI?sap-ui2-tcode=<TCODE>`
@@ -76,9 +78,11 @@ Run this sequence after deployment:
 7. Record the latest ST22 dump timestamp before UI execution.
 8. Launch ZTOAD and run only a read-only sanitized smoke query, initially `SELECT SINGLE mandt FROM t000`.
 9. Verify expected UI/result state and confirm ST22 has no new dump.
-10. Repeat on the other SAP target.
+10. Do not repeat the browser portion on NPL; repeat only the ADT activation/syntax/Unit/ATC gates there.
 
-If FLP cannot open WebGUI because the automation browser blocks a popup, record that environmental failure and use the standalone HTTPS WebGUI URL as a secondary diagnostic path. A missing `TRAN` object, application dump, or new ST22 entry remains a product gate failure.
+If FLP cannot open WebGUI because the automation browser blocks a popup, record that environmental failure and use the standalone HTTPS WebGUI URL as a secondary diagnostic path. Before interpreting a runtime failure, verify that the installed report contains the serialized dynpros and GUI statuses required by the test. Classify missing installation metadata separately from a product-code regression, but keep the overall smoke gate blocked until both are green.
+
+For `BASE-RUN-001`, editor startup/render/input and the ST22 delta are green on A4H. Query dispatch remains blocked because installed GUI status `STATUS010` is missing (`BASE-BUG-007`), despite being present in repository XML.
 
 `BASE-RUN-001` currently blocks steps 8–9 in WebGUI because `CL_GUI_ABAPEDIT` dumps. Until fixed, unit/syntax/ATC checks remain valid, but browser end-to-end status is failed rather than skipped.
 
@@ -105,7 +109,7 @@ A release candidate is accepted only when:
 - SAP_BASIS 750 and A4H 758 activate and pass syntax;
 - all ABAP Unit tests pass on both systems;
 - the selected ATC variants have no new unapproved finding;
-- the read-only UI smoke suite passes with no new ST22 dump;
+- the A4H read-only UI smoke suite passes with no new ST22 dump;
 - the finding register and changelog/release metadata are updated.
 
 An unavailable live system is a missing gate, not a pass. Record it and complete it before release unless the maintainer explicitly accepts the risk.

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -71,12 +71,12 @@ Run this sequence after deployment:
 
 1. Confirm native abapGit points at `master` and its check is clean.
 2. Confirm no unrelated inactive divergence and record the exact candidate commit/source hash being tested.
-3. Deploy and activate only the intended changed objects. Do not describe an unmerged directly deployed source as a native-abapGit `master` pull.
-4. Run SAP syntax.
+3. Deploy and explicitly activate only the intended changed objects. Do not describe an unmerged directly deployed source as a native-abapGit `master` pull, and do not rely on a write request's activation option.
+4. Confirm active and inactive source are identical, then run active SAP syntax.
 5. Run all ABAP Unit tests; require zero failures.
 6. Run the recorded ATC variants and inspect prerequisite/check errors. A result with missing prerequisites is incomplete even when no finding rows are displayed.
 7. Record the latest ST22 dump timestamp before UI execution.
-8. Launch ZTOAD and run only a read-only sanitized smoke query, initially `SELECT SINGLE mandt FROM t000`.
+8. Verify the installed dynpro and GUI status required by the scenario, then launch ZTOAD in a fresh browser session and run only a read-only sanitized smoke query, initially `SELECT SINGLE mandt FROM t000`.
 9. Verify expected UI/result state and confirm ST22 has no new dump.
 10. Do not repeat the browser portion on NPL; repeat only the ADT activation/syntax/Unit/ATC gates there.
 
@@ -84,7 +84,7 @@ If FLP cannot open WebGUI because the automation browser blocks a popup, record 
 
 For `BASE-RUN-001`, editor startup/render/input and the ST22 delta are green on A4H. Query dispatch remains blocked because installed GUI status `STATUS010` is missing (`BASE-BUG-007`), despite being present in repository XML.
 
-`BASE-RUN-001` currently blocks steps 8–9 in WebGUI because `CL_GUI_ABAPEDIT` dumps. Until fixed, unit/syntax/ATC checks remain valid, but browser end-to-end status is failed rather than skipped.
+For GUI-control changes, a green policy Unit test proves only the selection decision. The chosen control remains a spike until a fresh live session renders it, the intended interaction works, and ST22 stays unchanged. If a spike merely moves the dump to another constructor or event path, reject it and update the root-cause model before implementation continues.
 
 ## Database-writing integration tests
 

--- a/src/ztoad.prog.abap
+++ b/src/ztoad.prog.abap
@@ -255,6 +255,7 @@ DATA : BEGIN OF s_customize,                                "#EC NEEDED
 *######################################################################*
 * Objects
 CLASS lcl_application DEFINITION DEFERRED.
+CLASS lcl_editor DEFINITION DEFERRED.
 
 * Screen objects
 DATA : o_handle_event         TYPE REF TO lcl_application,
@@ -272,7 +273,7 @@ DATA : o_handle_event         TYPE REF TO lcl_application,
 
 * Tabs objects (editor, ddic, alv)
        BEGIN OF s_tab_active,
-         o_textedit             TYPE REF TO cl_gui_abapedit,
+         o_textedit             TYPE REF TO lcl_editor,
          o_tree_ddic            TYPE REF TO cl_gui_column_tree,
          t_node_ddic            TYPE treev_ntab,
          t_item_ddic            TYPE TABLE OF mtreeitm,
@@ -400,6 +401,69 @@ CLASS lcl_drag_object DEFINITION FINAL.
 ENDCLASS."lcl_drag_object DEFINITION
 
 *----------------------------------------------------------------------*
+*       CLASS lcl_editor_configuration DEFINITION
+*----------------------------------------------------------------------*
+*       Select editor behavior without depending on a live frontend
+*----------------------------------------------------------------------*
+CLASS lcl_editor_configuration DEFINITION FINAL.
+  PUBLIC SECTION.
+    CLASS-METHODS get_editor_type
+      IMPORTING i_webgui             TYPE abap_bool
+      RETURNING VALUE(r_editor_type) TYPE string.
+ENDCLASS.
+
+*----------------------------------------------------------------------*
+*       CLASS lcl_editor DEFINITION
+*----------------------------------------------------------------------*
+*       Common API for the desktop source editor and WebGUI text editor
+*----------------------------------------------------------------------*
+CLASS lcl_editor DEFINITION FINAL.
+  PUBLIC SECTION.
+    METHODS constructor
+      IMPORTING i_parent TYPE REF TO cl_gui_container
+                i_webgui TYPE abap_bool.
+    METHODS is_ready
+      RETURNING VALUE(r_ready) TYPE abap_bool.
+    METHODS get_abap_editor
+      RETURNING VALUE(r_editor) TYPE REF TO cl_gui_abapedit.
+    METHODS get_selection_pos
+      EXPORTING e_from_line TYPE i
+                e_from_pos  TYPE i
+                e_to_line   TYPE i
+                e_to_pos    TYPE i
+      EXCEPTIONS operation_failed.
+    METHODS get_selected_text_as_table
+      EXPORTING e_table TYPE STANDARD TABLE.
+    METHODS get_text
+      EXPORTING e_table TYPE STANDARD TABLE
+      EXCEPTIONS operation_failed.
+    METHODS delete_text
+      IMPORTING i_from_line TYPE i
+                i_from_pos  TYPE i
+                i_to_line   TYPE i
+                i_to_pos    TYPE i.
+    METHODS set_text
+      IMPORTING i_table TYPE STANDARD TABLE.
+    METHODS set_visible
+      IMPORTING i_visible TYPE abap_bool.
+    METHODS set_textmodified_status.
+    METHODS get_textmodified_status
+      RETURNING VALUE(r_status) TYPE i.
+    METHODS insert_block_at_position
+      IMPORTING i_line     TYPE i
+                i_pos      TYPE i
+                i_text_tab TYPE STANDARD TABLE.
+    METHODS set_selection_pos_in_line
+      IMPORTING i_line TYPE i
+                i_pos  TYPE i.
+    METHODS set_focus.
+
+  PRIVATE SECTION.
+    DATA abap_editor TYPE REF TO cl_gui_abapedit.
+    DATA text_editor TYPE REF TO cl_gui_textedit.
+ENDCLASS.
+
+*----------------------------------------------------------------------*
 *       CLASS lcl_application DEFINITION
 *----------------------------------------------------------------------*
 *       Class to handle application events
@@ -449,6 +513,235 @@ CLASS lcl_application DEFINITION FINAL.
                     FOR EVENT function_selected OF cl_gui_toolbar
         IMPORTING fcode.
 ENDCLASS.                    "lcl_application DEFINITION
+
+CLASS lcl_editor_configuration IMPLEMENTATION.
+  METHOD get_editor_type.
+    IF i_webgui = abap_true.
+      r_editor_type = 'TEXT'.
+    ELSE.
+      r_editor_type = 'ABAP'.
+    ENDIF.
+  ENDMETHOD.
+ENDCLASS.
+
+CLASS lcl_editor IMPLEMENTATION.
+  METHOD constructor.
+    IF lcl_editor_configuration=>get_editor_type( i_webgui ) = 'TEXT'.
+      CREATE OBJECT text_editor
+        EXPORTING
+          parent                   = i_parent
+        EXCEPTIONS
+          error_cntl_create      = 1
+          error_cntl_init        = 2
+          error_cntl_link        = 3
+          error_dp_create        = 4
+          gui_type_not_supported = 5
+          OTHERS                 = 6.
+    ELSE.
+      abap_editor = NEW cl_gui_abapedit( parent = i_parent ).
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD is_ready.
+    r_ready = xsdbool( text_editor IS BOUND OR abap_editor IS BOUND ).
+  ENDMETHOD.
+
+  METHOD get_abap_editor.
+    r_editor = abap_editor.
+  ENDMETHOD.
+
+  METHOD get_selection_pos.
+    IF text_editor IS BOUND.
+      text_editor->get_selection_pos(
+        IMPORTING
+          from_line = e_from_line
+          from_pos  = e_from_pos
+          to_line   = e_to_line
+          to_pos    = e_to_pos
+        EXCEPTIONS
+          OTHERS    = 1 ).
+    ELSE.
+      abap_editor->get_selection_pos(
+        IMPORTING
+          from_line = e_from_line
+          from_pos  = e_from_pos
+          to_line   = e_to_line
+          to_pos    = e_to_pos
+        EXCEPTIONS
+          OTHERS    = 1 ).
+    ENDIF.
+
+    IF sy-subrc <> 0.
+      RAISE operation_failed.
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD get_selected_text_as_table.
+    IF text_editor IS BOUND.
+      text_editor->get_selected_text_as_r3table(
+        IMPORTING
+          table  = e_table
+        EXCEPTIONS
+          OTHERS = 0 ).
+    ELSE.
+      abap_editor->get_selected_text_as_table(
+        IMPORTING
+          table  = e_table
+        EXCEPTIONS
+          OTHERS = 0 ).
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD get_text.
+    IF text_editor IS BOUND.
+      text_editor->get_text_as_r3table(
+        IMPORTING
+          table  = e_table
+        EXCEPTIONS
+          OTHERS = 1 ).
+    ELSE.
+      abap_editor->get_text(
+        IMPORTING
+          table  = e_table
+        EXCEPTIONS
+          OTHERS = 1 ).
+    ENDIF.
+
+    IF sy-subrc <> 0.
+      RAISE operation_failed.
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD delete_text.
+    DATA empty_text TYPE soli_tab.
+
+    IF text_editor IS BOUND.
+      text_editor->set_selection_pos(
+        EXPORTING
+          from_line = i_from_line
+          from_pos  = i_from_pos
+          to_line   = i_to_line
+          to_pos    = i_to_pos
+        EXCEPTIONS
+          OTHERS    = 0 ).
+      text_editor->set_selected_text_as_r3table(
+        EXPORTING
+          table  = empty_text
+        EXCEPTIONS
+          OTHERS = 0 ).
+    ELSE.
+      abap_editor->delete_text(
+        from_line = i_from_line
+        from_pos  = i_from_pos
+        to_line   = i_to_line
+        to_pos    = i_to_pos ).
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD set_text.
+    IF text_editor IS BOUND.
+      text_editor->set_text_as_r3table(
+        EXPORTING
+          table  = i_table
+        EXCEPTIONS
+          OTHERS = 0 ).
+    ELSE.
+      abap_editor->set_text(
+        EXPORTING
+          table  = i_table
+        EXCEPTIONS
+          OTHERS = 0 ).
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD set_visible.
+    IF text_editor IS BOUND.
+      text_editor->set_visible( visible = i_visible ).
+    ELSE.
+      abap_editor->set_visible( visible = i_visible ).
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD set_textmodified_status.
+    IF text_editor IS BOUND.
+      text_editor->set_textmodified_status( ).
+    ELSE.
+      abap_editor->set_textmodified_status( ).
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD get_textmodified_status.
+    IF text_editor IS BOUND.
+      text_editor->get_textmodified_status(
+        IMPORTING
+          status = r_status
+        EXCEPTIONS
+          OTHERS = 0 ).
+    ELSE.
+      abap_editor->get_textmodified_status(
+        IMPORTING
+          status = r_status
+        EXCEPTIONS
+          OTHERS = 0 ).
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD insert_block_at_position.
+    IF text_editor IS BOUND.
+      text_editor->set_selection_pos(
+        EXPORTING
+          from_line = i_line
+          from_pos  = i_pos
+          to_line   = i_line
+          to_pos    = i_pos
+        EXCEPTIONS
+          OTHERS    = 0 ).
+      text_editor->set_selected_text_as_stream(
+        EXPORTING
+          selected_text = i_text_tab
+        EXCEPTIONS
+          OTHERS        = 0 ).
+    ELSE.
+      abap_editor->insert_block_at_position(
+        EXPORTING
+          line     = i_line
+          pos      = i_pos
+          text_tab = i_text_tab
+        EXCEPTIONS
+          OTHERS   = 0 ).
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD set_selection_pos_in_line.
+    IF text_editor IS BOUND.
+      text_editor->set_selection_pos_in_line(
+        EXPORTING
+          line   = i_line
+          pos    = i_pos
+        EXCEPTIONS
+          OTHERS = 0 ).
+    ELSE.
+      abap_editor->set_selection_pos_in_line(
+        EXPORTING
+          line   = i_line
+          pos    = i_pos
+        EXCEPTIONS
+          OTHERS = 0 ).
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD set_focus.
+    IF text_editor IS BOUND.
+      cl_gui_control=>set_focus(
+        EXPORTING control = text_editor
+        EXCEPTIONS OTHERS = 0 ).
+    ELSE.
+      cl_gui_control=>set_focus(
+        EXPORTING control = abap_editor
+        EXCEPTIONS OTHERS = 0 ).
+    ENDIF.
+  ENDMETHOD.
+ENDCLASS.
 
 *----------------------------------------------------------------------*
 *       CLASS LCL_APPLICATION IMPLEMENTATION
@@ -560,10 +853,10 @@ CLASS lcl_application IMPLEMENTATION.
 * Find active query
     CALL METHOD s_tab_active-o_textedit->get_selection_pos
       IMPORTING
-        from_line = lw_cursor_line_from
-        from_pos  = lw_cursor_pos_from
-        to_line   = lw_cursor_line_to
-        to_pos    = lw_cursor_pos_to.
+        e_from_line = lw_cursor_line_from
+        e_from_pos  = lw_cursor_pos_from
+        e_to_line   = lw_cursor_line_to
+        e_to_pos    = lw_cursor_pos_to.
 
 * If nothing selected, no help to display
     IF lw_cursor_line_from = lw_cursor_line_to
@@ -574,7 +867,7 @@ CLASS lcl_application IMPLEMENTATION.
 * Get content of abap edit box
     CALL METHOD s_tab_active-o_textedit->get_text
       IMPORTING
-        table  = lt_query[]
+        e_table = lt_query[]
       EXCEPTIONS
         OTHERS = 1.
 
@@ -621,10 +914,10 @@ CLASS lcl_application IMPLEMENTATION.
 * Get current cursor position/selection in editor
     CALL METHOD s_tab_active-o_textedit->get_selection_pos
       IMPORTING
-        from_line = lw_line_start
-        from_pos  = lw_pos_start
-        to_line   = lw_line_end
-        to_pos    = lw_pos_end
+        e_from_line = lw_line_start
+        e_from_pos  = lw_pos_start
+        e_to_line   = lw_line_end
+        e_to_pos    = lw_pos_end
       EXCEPTIONS
         OTHERS    = 4.
     IF sy-subrc NE 0.
@@ -636,10 +929,10 @@ CLASS lcl_application IMPLEMENTATION.
     OR lw_pos_start NE lw_pos_end.
       CALL METHOD s_tab_active-o_textedit->delete_text
         EXPORTING
-          from_line = lw_line_start
-          from_pos  = lw_pos_start
-          to_line   = lw_line_end
-          to_pos    = lw_pos_end.
+          i_from_line = lw_line_start
+          i_from_pos  = lw_pos_start
+          i_to_line   = lw_line_end
+          i_to_pos    = lw_pos_end.
     ENDIF.
 
     PERFORM editor_paste USING lw_data lw_line_start lw_pos_start.
@@ -661,7 +954,7 @@ CLASS lcl_application IMPLEMENTATION.
 
       CALL METHOD s_tab_active-o_textedit->set_text
         EXPORTING
-          table  = lt_query
+          i_table = lt_query
         EXCEPTIONS
           OTHERS = 0.
 
@@ -885,7 +1178,7 @@ MODULE user_command_0010 INPUT.
 * Display editor / ddic / alv
         CALL METHOD s_tab_active-o_textedit->set_visible
           EXPORTING
-            visible = abap_true.
+            i_visible = abap_true.
         CALL METHOD s_tab_active-o_tree_ddic->set_visible
           EXPORTING
             visible = abap_true.
@@ -1131,7 +1424,9 @@ FORM editor_init.
          ls_event      TYPE cntl_simple_event,
          lt_default    TYPE TABLE OF string,
          lw_queryid    TYPE ztoad-queryid,
-         lo_dragrop    TYPE REF TO cl_dragdrop,
+         dragdrop      TYPE REF TO cl_dragdrop,
+         abap_editor   TYPE REF TO cl_gui_abapedit,
+         completer     TYPE REF TO cl_abap_parser,
          lw_dummy_date TYPE timestamp.                      "#EC NEEDED
 
 * For first tab, Get last query used
@@ -1165,71 +1460,73 @@ FORM editor_init.
 
   CREATE OBJECT s_tab_active-o_textedit
     EXPORTING
-      parent = o_container_query.
-
-* Register events
-  SET HANDLER o_handle_event->hnd_editor_f1 FOR s_tab_active-o_textedit.
-  SET HANDLER o_handle_event->hnd_editor_drop FOR s_tab_active-o_textedit.
-
-  ls_event-eventid = cl_gui_textedit=>event_f1.
-  APPEND ls_event TO lt_events.
-
-  CALL METHOD s_tab_active-o_textedit->set_registered_events
-    EXPORTING
-      events                    = lt_events
-    EXCEPTIONS
-      cntl_error                = 1
-      cntl_system_error         = 2
-      illegal_event_combination = 3.
-  IF sy-subrc <> 0.
-    IF sy-msgno IS NOT INITIAL.
-      MESSAGE ID sy-msgid TYPE sy-msgty NUMBER sy-msgno
-              DISPLAY LIKE c_msg_error
-              WITH sy-msgv1 sy-msgv2 sy-msgv3 sy-msgv4 .
-    ENDIF.
+      i_parent = o_container_query
+      i_webgui = xsdbool( cl_gui_control=>www_active IS NOT INITIAL ).
+  IF s_tab_active-o_textedit->is_ready( ) = abap_false.
+    MESSAGE 'The query editor cannot be created' TYPE c_msg_error.
+    RETURN.
   ENDIF.
+
+  abap_editor = s_tab_active-o_textedit->get_abap_editor( ).
+
+* The ABAP source editor and its completer are not supported by WebGUI.
+  IF abap_editor IS BOUND.
+* Register events
+    SET HANDLER o_handle_event->hnd_editor_f1 FOR abap_editor.
+    SET HANDLER o_handle_event->hnd_editor_drop FOR abap_editor.
+
+    ls_event-eventid = cl_gui_textedit=>event_f1.
+    APPEND ls_event TO lt_events.
+
+    abap_editor->set_registered_events(
+      EXPORTING
+        events                    = lt_events
+      EXCEPTIONS
+        cntl_error                = 1
+        cntl_system_error         = 2
+        illegal_event_combination = 3 ).
+    IF sy-subrc <> 0.
+      IF sy-msgno IS NOT INITIAL.
+        MESSAGE ID sy-msgid TYPE sy-msgty NUMBER sy-msgno
+                DISPLAY LIKE c_msg_error
+                WITH sy-msgv1 sy-msgv2 sy-msgv3 sy-msgv4.
+      ENDIF.
+    ENDIF.
 
 * Activate Code Completion and Quickinfo
 * Comment the paragraph if CL_ABAP_PARSER doesnt exists on your system
 * BEGIN OF ABAP PARSER
-  DATA lo_completer TYPE REF TO cl_abap_parser.
-  CALL METHOD s_tab_active-o_textedit->('INIT_COMPLETER').
-  CALL METHOD s_tab_active-o_textedit->('GET_COMPLETER')
-    RECEIVING
-      m_parser = lo_completer.
-  SET HANDLER lo_completer->handle_completion_request FOR s_tab_active-o_textedit.
-  SET HANDLER lo_completer->handle_insertion_request FOR s_tab_active-o_textedit.
-  SET HANDLER lo_completer->handle_quickinfo_request FOR s_tab_active-o_textedit.
-  s_tab_active-o_textedit->register_event_completion( ).
-  s_tab_active-o_textedit->register_event_quick_info( ).
-  s_tab_active-o_textedit->register_event_insert_pattern( ).
+    CALL METHOD abap_editor->('INIT_COMPLETER').
+    CALL METHOD abap_editor->('GET_COMPLETER')
+      RECEIVING
+        m_parser = completer.
+    SET HANDLER completer->handle_completion_request FOR abap_editor.
+    SET HANDLER completer->handle_insertion_request FOR abap_editor.
+    SET HANDLER completer->handle_quickinfo_request FOR abap_editor.
+    abap_editor->register_event_completion( ).
+    abap_editor->register_event_quick_info( ).
+    abap_editor->register_event_insert_pattern( ).
 * END OF ABAP PARSER
 
 * Manage Drop on SQL editor
-  CREATE OBJECT lo_dragrop.
-  CALL METHOD lo_dragrop->add
-    EXPORTING
+    dragdrop = NEW cl_dragdrop( ).
+    dragdrop->add(
       flavor     = 'EDIT_INSERT'
       dragsrc    = space
       droptarget = abap_true
-      effect     = cl_dragdrop=>copy.
-  CALL METHOD s_tab_active-o_textedit->set_dragdrop
-    EXPORTING
-      dragdrop = lo_dragrop.
+      effect     = cl_dragdrop=>copy ).
+    abap_editor->set_dragdrop( dragdrop = dragdrop ).
+  ENDIF.
 
 * Set Default template
   CALL METHOD s_tab_active-o_textedit->set_text
     EXPORTING
-      table  = lt_default
+      i_table = lt_default
     EXCEPTIONS
       OTHERS = 0.
 
 * Set focus
-  CALL METHOD cl_gui_control=>set_focus
-    EXPORTING
-      control = s_tab_active-o_textedit
-    EXCEPTIONS
-      OTHERS  = 0.
+  s_tab_active-o_textedit->set_focus( ).
 
   PERFORM ddic_refresh_tree.
 ENDFORM.                    " EDITOR_INIT
@@ -1474,13 +1771,13 @@ FORM editor_get_query USING fw_force_last TYPE c
 * Get selected content
   CALL METHOD s_tab_active-o_textedit->get_selected_text_as_table
     IMPORTING
-      table = lt_query[].
+      e_table = lt_query[].
 
 * if no selected content, get complete content of abap edit box
   IF lt_query[] IS INITIAL.
     CALL METHOD s_tab_active-o_textedit->get_text
       IMPORTING
-        table  = lt_query[]
+        e_table = lt_query[]
       EXCEPTIONS
         OTHERS = 1.
   ENDIF.
@@ -1523,8 +1820,8 @@ FORM editor_get_query USING fw_force_last TYPE c
 * Find active query
   CALL METHOD s_tab_active-o_textedit->get_selection_pos
     IMPORTING
-      from_line = lw_cursor_line
-      from_pos  = lw_cursor_pos.
+      e_from_line = lw_cursor_line
+      e_from_pos  = lw_cursor_pos.
   lw_cursor_offset = lw_cursor_pos - 1.
 
   FIND ALL OCCURRENCES OF '.' IN TABLE lt_query RESULTS lt_find.
@@ -2743,7 +3040,7 @@ FORM repo_save_query.
 * Get content of abap edit box
   CALL METHOD s_tab_active-o_textedit->get_text
     IMPORTING
-      table  = lt_query[]
+      e_table = lt_query[]
     EXCEPTIONS
       OTHERS = 1.
 
@@ -3013,7 +3310,7 @@ FORM repo_save_current_query.
 * Get content of abap edit box
   CALL METHOD s_tab_active-o_textedit->get_text
     IMPORTING
-      table  = lt_query[]
+      e_table = lt_query[]
     EXCEPTIONS
       OTHERS = 1.
 
@@ -3209,9 +3506,7 @@ FORM screen_exit.
   ENDIF.
 
 * Check if textedit is modified
-  CALL METHOD s_tab_active-o_textedit->get_textmodified_status
-    IMPORTING
-      status = lw_status.
+  lw_status = s_tab_active-o_textedit->get_textmodified_status( ).
   IF lw_status NE 0.
     CONCATENATE 'Current query is not saved. Do you want'(m22)
 'to exit without saving or save into history then exit ?'(m56)
@@ -3747,9 +4042,9 @@ FORM editor_paste  USING fw_text TYPE string
 
   CALL METHOD s_tab_active-o_textedit->insert_block_at_position
     EXPORTING
-      line     = fw_line
-      pos      = fw_pos
-      text_tab = lt_text
+      i_line     = fw_line
+      i_pos      = fw_pos
+      i_text_tab = lt_text
     EXCEPTIONS
       OTHERS   = 0.
 
@@ -3765,17 +4060,13 @@ FORM editor_paste  USING fw_text TYPE string
 
   CALL METHOD s_tab_active-o_textedit->set_selection_pos_in_line
     EXPORTING
-      line   = lw_line
-      pos    = lw_pos
+      i_line = lw_line
+      i_pos  = lw_pos
     EXCEPTIONS
       OTHERS = 0.
 
 * Focus on editor
-  CALL METHOD cl_gui_control=>set_focus
-    EXPORTING
-      control = s_tab_active-o_textedit
-    EXCEPTIONS
-      OTHERS  = 0.
+  s_tab_active-o_textedit->set_focus( ).
 
   CONCATENATE fw_text 'pasted to SQL Editor'(m27)
               INTO lw_message SEPARATED BY space.
@@ -4561,10 +4852,10 @@ FORM ddic_f4.
 * Get current cursor position/selection in editor
     CALL METHOD s_tab_active-o_textedit->get_selection_pos
       IMPORTING
-        from_line = lw_line_start
-        from_pos  = lw_pos_start
-        to_line   = lw_line_end
-        to_pos    = lw_pos_end
+        e_from_line = lw_line_start
+        e_from_pos  = lw_pos_start
+        e_to_line   = lw_line_end
+        e_to_pos    = lw_pos_end
       EXCEPTIONS
         OTHERS    = 4.
     IF sy-subrc NE 0.
@@ -4576,10 +4867,10 @@ FORM ddic_f4.
     OR lw_pos_start NE lw_pos_end.
       CALL METHOD s_tab_active-o_textedit->delete_text
         EXPORTING
-          from_line = lw_line_start
-          from_pos  = lw_pos_start
-          to_line   = lw_line_end
-          to_pos    = lw_pos_end.
+          i_from_line = lw_line_start
+          i_from_pos  = lw_pos_start
+          i_to_line   = lw_line_end
+          i_to_pos    = lw_pos_end.
     ENDIF.
 
     PERFORM editor_paste USING lw_val lw_line_start lw_pos_start.
@@ -4668,7 +4959,7 @@ FORM leave_current_tab.
 * Hide current editor / ddic / alv
   CALL METHOD s_tab_active-o_textedit->set_visible
     EXPORTING
-      visible = space.
+      i_visible = space.
 
   CALL METHOD s_tab_active-o_tree_ddic->set_visible
     EXPORTING
@@ -4721,7 +5012,7 @@ FORM tab_update_title USING fw_query TYPE string.
 * Basic read query to check if first line is a comment
   CALL METHOD s_tab_active-o_textedit->get_text
     IMPORTING
-      table  = lt_query[]
+      e_table = lt_query[]
     EXCEPTIONS
       OTHERS = 1.
   READ TABLE lt_query INTO ls_query INDEX 1.
@@ -5073,6 +5364,34 @@ CLASS ltc_query_parser DEFINITION FINAL
                 no_authority TYPE abap_bool
                 new_syntax TYPE abap_bool
                 parse_error TYPE abap_bool.
+ENDCLASS.
+
+
+CLASS ltcl_editor_configuration DEFINITION FINAL
+  FOR TESTING
+  DURATION SHORT
+  RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS uses_text_editor_in_webgui FOR TESTING.
+    METHODS keeps_abap_mode_elsewhere FOR TESTING.
+ENDCLASS.
+
+CLASS ltcl_editor_configuration IMPLEMENTATION.
+  METHOD uses_text_editor_in_webgui.
+    cl_abap_unit_assert=>assert_equals(
+      act = lcl_editor_configuration=>get_editor_type(
+              i_webgui = abap_true )
+      exp = 'TEXT'
+      msg = 'WebGUI must use its supported plain text editor' ).
+  ENDMETHOD.
+
+  METHOD keeps_abap_mode_elsewhere.
+    cl_abap_unit_assert=>assert_equals(
+      act = lcl_editor_configuration=>get_editor_type(
+              i_webgui = abap_false )
+      exp = 'ABAP'
+      msg = 'Desktop GUI must retain ABAP editor behavior' ).
+  ENDMETHOD.
 ENDCLASS.
 
 CLASS ltc_query_parser IMPLEMENTATION.

--- a/system-info.md
+++ b/system-info.md
@@ -1,6 +1,6 @@
 # System Info: A4H / ZTOAD test matrix
 
-_Generated: 2026-08-06T05:54:28Z_ · _Source: live ARC-1 discovery, native abapGit, SAP syntax/Unit/ATC runs, and WebGUI smoke testing_
+_Updated: 2026-08-06_ · _Source: live ARC-1 discovery on A4H and NPL, native abapGit, SAP syntax/Unit/ATC runs, and A4H WebGUI smoke testing_
 
 ## Identity
 
@@ -48,7 +48,7 @@ The first request created during setup, `A4HK906377`, is an empty local request 
 - **ARC-1 rule inventory**: 158 enabled, 25 disabled
 - **Repository gate**: pinned `@abaplint/cli` with the compatibility-focused rules in `abaplint.json`
 - **Compatibility floor**: SAP_BASIS 750; the separate 7.50 system is still required for the authoritative downport gate
-- **Baseline full-rule audit**: 1,086 findings (992 errors, 94 warnings) across 35 rules; tracked in `docs/baseline-findings.md`
+- **Baseline full-rule audit**: 1,857 findings across 57 rules on `master`; BASE-RUN-001 candidate 1,878 with 21 explained adapter diagnostics
 
 ## RAP Constraints Snapshot
 
@@ -69,10 +69,11 @@ The first request created during setup, `A4HK906377`, is an empty local request 
 | Repository objects | PROG `ZTOAD`, TABL `ZTOAD`, SUSO `ZTOAD_AUTH` |
 | Active/inactive source | Identical; no inactive divergence |
 | SAP syntax | 0 errors; 4 warnings |
-| ABAP Unit | 14 passed, 0 failed |
-| ATC `S4HANA_READINESS_2023` | 0 findings |
-| ATC `ABAP_CLOUD_READINESS` | 758 findings; classic Dynpro/GUI design is not ABAP Cloud compatible |
-| WebGUI smoke | Failed with `RAISE_EXCEPTION` / `DATA_SOURCE_ERROR` in `DP_PUBLISH_URL` from `CL_GUI_ABAPEDIT=>CONSTRUCTOR` |
+| ABAP Unit | 19 passed, 0 failed |
+| ATC `S4HANA_READINESS_2023` | 0 rows returned; non-authoritative because known prerequisites are unavailable |
+| ATC `ABAP_CLOUD_READINESS` | 768 findings (463 P1, 305 P2); classic Dynpro/GUI design is not ABAP Cloud compatible |
+| WebGUI smoke | Fresh final launch renders the plain text editor and accepts `SELECT SINGLE mandt FROM t000`; no new ST22 dump |
+| Remaining UI prerequisite | A4H installation lacks GUI status `STATUS010`, so query dispatch is blocked by `BASE-BUG-007` |
 
 ## Coding Guidance
 
@@ -82,18 +83,24 @@ The first request created during setup, `A4HK906377`, is an empty local request 
 - Never infer browser compatibility from activation. The current `CL_GUI_ABAPEDIT` path is proven to dump in WebGUI and needs a tested fallback or replacement.
 - Keep native SQL disabled by default. Any parser/executor change needs explicit authorization, injection, row-limit, and error-leakage tests.
 - Use native abapGit for complete object round trips. ARC-1 remains preferred for reads, targeted source writes, activation, syntax, ABAP Unit, ATC, object state, and ST22 diagnostics.
+- ARC-1 source writes must be followed by explicit activation and an object-state comparison. `activate=true` on the write request did not activate this candidate; the separate activation call did.
 
-## Secondary Target: ABAP 7.50
+## Secondary Target: NPL / ABAP 7.50
 
 | Field | Value |
 |---|---|
-| SID / URL / client | Not configured in this workspace yet |
-| Required release | SAP_BASIS 750 |
-| Purpose | Minimum-release deserialization, activation, syntax, ABAP Unit, ATC, and runtime gate |
-| ARC-1 | Configure as a separate server/profile such as `arc-1-750`; do not replace the A4H destination |
-| Completion status | Pending; no change may claim full two-system compatibility until this gate passes |
+| SID / client | NPL / 001 |
+| Release | SAP_BASIS 750 SP02; SAP_ABA, SAP_UI, and SAP_GWFND 750 SP02 |
+| Purpose | ADT-only minimum-release activation, syntax, ABAP Unit, and ATC gate |
+| ARC-1 | Separate `arc-1-750` profile, pinned to ARC-1 1.0.2; write/activate/syntax/Unit/cleanup lifecycle proven |
+| UI boundary | No FLP, WebGUI, SAP GUI, or browser automation; A4H owns UI smoke |
+| ZTOAD state | Program and transparent table are absent |
+| Blocking prerequisite | SAP_BASIS 750 exposes no ADT transparent-table create endpoint, so table `ZTOAD` cannot be safely provisioned through ARC-1 |
+| Completion status | Connection usable; exact ZTOAD activation/syntax/Unit/ATC blocked until the real table exists |
 
-## Verified Access Paths
+See [the NPL ADT-only validation dossier](docs/research/2026-08-06-npl-adt-only-validation.md). A disposable report was created, activated, syntax-checked, unit-tested successfully, deleted, and confirmed absent. No stub DDIC structure may be used to claim compatibility.
+
+## Verified A4H Access Paths
 
 - FLP transaction intent: `https://a4h.marianzeis.de/sap/bc/ui2/flp?sap-client=001#Shell-startGUI?sap-ui2-tcode=<TCODE>`
 - Standalone WebGUI: `https://a4h.marianzeis.de/sap/bc/gui/sap/its/webgui?sap-client=001&~transaction=<TCODE>`


### PR DESCRIPTION
## Goal

Fix BASE-RUN-001 so ZTOAD reaches a usable query editor in SAP WebGUI without creating a new ST22 dump.

## What changed

- add a narrow editor adapter that uses `CL_GUI_TEXTEDIT` in WebGUI and retains `CL_GUI_ABAPEDIT` on desktop SAP GUI
- preserve desktop F1, completion, quick-info, insert-pattern, and drag/drop behavior
- add two ABAP Unit tests for the frontend-selection policy
- document the rejected SQL source-type spike, live root cause, NPL ADT-only target, and current validation/process evidence

## Root cause

`CL_GUI_ABAPEDIT` publishes ABAP lexer data through `DP_PUBLISH_URL` and is not usable in the tested WebGUI runtime. Changing only its source type avoided the lexer call but left an invalid source-editor control handle and produced a second live dump.

## Validation

- `npm ci`: passed, 0 vulnerabilities
- `npm test`: 0 configured abaplint findings
- `git diff --check`: passed
- A4H active source: no inactive divergence
- A4H syntax: 0 errors, 4 unchanged legacy warnings
- A4H ABAP Unit: 19 passed, 0 failed
- A4H ATC `ABAP_CLOUD_READINESS`: 768 findings (463 P1, 305 P2), recorded as architectural debt
- A4H ATC `S4HANA_READINESS_2023`: no rows returned, but known prerequisites remain unavailable
- fresh WebGUI launch: editor renders and accepts `SELECT SINGLE mandt FROM t000`
- post-smoke ST22: no new dump

## Known gates

- Full query dispatch is blocked by the A4H installation missing GUI status `STATUS010`, tracked separately as BASE-BUG-007 even though the status exists in repository XML.
- Exact NPL/7.50 ZTOAD activation is blocked because transparent table `ZTOAD` is absent and SAP_BASIS 750 has no ADT transparent-table create endpoint. NPL remains ARC-1/ADT-only; no FLP or SAPGUI automation is used there.