### PR TITLE
docs: remove private SAP endpoint

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -59,9 +59,10 @@ Setup procedure:
 
 If the ARC-1 abapGit bridge is used to restore the shared branch after a coordinated round trip, pass `refs/heads/master`, not only `master`, and verify the selected branch with a fresh `list_repos` call. On the current A4H bridge the short value returned success without changing the repository, while the full ref switched it correctly. Re-run the inactive-child contract after restoration.
 
-On A4H, the Fiori-shell URL for the transaction is:
+On A4H, load the private system base URL from the ignored `.env` file as
+`SAP_URL`. The Fiori-shell URL for the transaction is:
 
-`https://a4h.marianzeis.de/sap/bc/ui2/flp?sap-client=001#Shell-startGUI?sap-ui2-tcode=ZABAPGIT`
+`${SAP_URL}/sap/bc/ui2/flp?sap-client=001#Shell-startGUI?sap-ui2-tcode=ZABAPGIT`
 
 Do not manually install only the report source. That omits the dynpros, table, authorization object, and transaction and cannot reproduce a supported installation. The repository-managed launcher is report transaction `ZTOAD` for program `ZTOAD`; use `#Shell-startGUI?sap-ui2-tcode=ZTOAD` or standalone `~transaction=ZTOAD` for its A4H smoke test.
 

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -65,10 +65,11 @@ Each parser/generator change should select relevant cases from this matrix:
 
 NPL/SAP_BASIS 750 validation is ARC-1/ADT-only. Run activation, syntax, ABAP Unit, ATC, and inactive-object checks there; do not use FLP, WebGUI, SAP GUI, or browser automation for test execution. The complete object set was provisioned once by the maintainer through native abapGit's offline ZIP workflow because the real transparent table cannot be created through the 7.50 ADT surface. Future source candidates use ARC-1; future structural refreshes require another reviewed native-abapGit import rather than an unfaithful substitute.
 
-For A4H, use only the HTTPS reverse proxy:
+For A4H, load the private HTTPS reverse-proxy base URL from the ignored `.env`
+file as `SAP_URL`. Never commit a live SAP hostname. Build the access paths as:
 
-- FLP: `https://a4h.marianzeis.de/sap/bc/ui2/flp?sap-client=001#Shell-startGUI?sap-ui2-tcode=<TCODE>`
-- WebGUI: `https://a4h.marianzeis.de/sap/bc/gui/sap/its/webgui?sap-client=001&~transaction=<TCODE>`
+- FLP: `${SAP_URL}/sap/bc/ui2/flp?sap-client=001#Shell-startGUI?sap-ui2-tcode=<TCODE>`
+- WebGUI: `${SAP_URL}/sap/bc/gui/sap/its/webgui?sap-client=001&~transaction=<TCODE>`
 
 Do not use ports 50000 or 50001. Credentials stay in the ignored `.env` file and must never appear in test output or screenshots.
 

--- a/system-info.md
+++ b/system-info.md
@@ -10,7 +10,7 @@ _Updated: 2026-08-07_ · _Source: live ARC-1 discovery on A4H and NPL, native ab
 | System type | on-premise S/4HANA |
 | Release | ABAP Platform 2023 / SAP_BASIS 758 SP02 |
 | Kernel | Not reported by the available ADT discovery endpoints |
-| Host | `https://a4h.marianzeis.de` (HTTPS reverse proxy; no SAP port suffix) |
+| Host | Private HTTPS reverse proxy loaded from ignored `.env` variable `SAP_URL`; no SAP port suffix |
 | Client | 001 |
 | Language | EN |
 | User | MARIAN |
@@ -105,6 +105,6 @@ See [the NPL ADT-only validation dossier](docs/research/2026-08-06-npl-adt-only-
 
 ## Verified A4H Access Paths
 
-- FLP transaction intent: `https://a4h.marianzeis.de/sap/bc/ui2/flp?sap-client=001#Shell-startGUI?sap-ui2-tcode=<TCODE>`
-- Standalone WebGUI: `https://a4h.marianzeis.de/sap/bc/gui/sap/its/webgui?sap-client=001&~transaction=<TCODE>`
+- FLP transaction intent: `${SAP_URL}/sap/bc/ui2/flp?sap-client=001#Shell-startGUI?sap-ui2-tcode=<TCODE>`
+- Standalone WebGUI: `${SAP_URL}/sap/bc/gui/sap/its/webgui?sap-client=001&~transaction=<TCODE>`
 - Do not use ports `50000` or `50001` from clients; only the HTTPS reverse proxy is supported.


### PR DESCRIPTION
## Summary

- remove every tracked occurrence of the private A4H hostname
- build documented FLP and WebGUI paths from the ignored `SAP_URL` environment variable
- state explicitly that live SAP hostnames must not be committed

## Scope

This changes documentation only. It does not alter ABAP source, repository-object metadata, release files, credentials, or either SAP system. Git history is intentionally not rewritten.

## Validation

- tracked-file and working-tree searches return no occurrence of the private hostname
- `npm test`
- `git diff --check`
